### PR TITLE
12 cache manager attribute

### DIFF
--- a/Sample/Controllers/MainController.cs
+++ b/Sample/Controllers/MainController.cs
@@ -65,6 +65,11 @@ public sealed class MainController : Controller
         return Task.FromResult<ActionResult<Book>>(Ok(newBook));
     }
 
+    /// <summary>
+    /// Gets a book using the [Cacheable] attribute with key derived from the route or query parameter (`bookId`).
+    /// Since no prefix is provided explicitly, the prefix will be automatically generated from the action descriptor's display name.
+    /// The final cache key format will be: {DisplayName}:{bookId}
+    /// </summary>
     [HttpGet("[action]/{bookId}")]
     [Cacheable(typeof(Book), CacheableKeyType.FromRouteOrQuery, "bookId")]
     public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithKeyFromRoute(int bookId, CancellationToken cancellationToken)
@@ -78,6 +83,11 @@ public sealed class MainController : Controller
         return Task.FromResult<ActionResult<Book>>(Ok(newBook));
     }
 
+    /// <summary>
+    /// Gets a book using the [Cacheable] attribute with key derived from the model (`book.id`).
+    /// Since no prefix is provided explicitly, the prefix will be automatically generated from the action descriptor's display name.
+    /// The final cache key format will be: {DisplayName}:{book.Id}
+    /// </summary>
     [Cacheable(typeof(Book), CacheableKeyType.FromModel, "book.id")]
     public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithKeyFromModel(Book book, CancellationToken cancellationToken)
     {
@@ -89,4 +99,22 @@ public sealed class MainController : Controller
 
         return Task.FromResult<ActionResult<Book>>(Ok(newBook));
     }
+    
+    /// <summary>
+    /// Gets a book using the [Cacheable] attribute with key derived from the model (`book.id`).
+    /// A custom prefix `"GetBook"` is explicitly provided, so it will be used instead of the default action descriptor display name.
+    /// The final cache key format will be: GetBook:{book.Id}
+    /// </summary>
+    [Cacheable(typeof(Book), CacheableKeyType.FromModel, "book.id", prefix: "GetBook")]
+    public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithKeyFromModelAndPrefix(Book book, CancellationToken cancellationToken)
+    {
+        var newBook = new Book
+        {
+            Id = book.Id,
+            Name = "Sample Book With Prefix"
+        };
+
+        return Task.FromResult<ActionResult<Book>>(Ok(newBook));
+    }
+
 }

--- a/Sample/Controllers/MainController.cs
+++ b/Sample/Controllers/MainController.cs
@@ -1,4 +1,5 @@
-﻿using CacheManager.Redis.Interfaces;
+﻿using CacheManager.Redis.Attributes;
+using CacheManager.Redis.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
 
@@ -29,5 +30,18 @@ public sealed class MainController : Controller
             SlidingExpiration = TimeSpan.FromDays(1)
         }, cancellationToken);
         return Ok(newBook);
+    }
+    
+    [HttpGet]
+    [Cacheable(typeof(Book), "book-key")]
+    public Task<ActionResult<Book>> GetBookWithCacheManagerAttributeAsync(CancellationToken cancellationToken)
+    {
+        var newBook = new Book
+        {
+            Id = 1,
+            Name = "Redis Cache Manager"
+        };
+
+        return Task.FromResult<ActionResult<Book>>(Ok(newBook));
     }
 }

--- a/Sample/Controllers/MainController.cs
+++ b/Sample/Controllers/MainController.cs
@@ -32,7 +32,20 @@ public sealed class MainController : Controller
         }, cancellationToken);
         return Ok(newBook);
     }
-    
+
+    [HttpGet]
+    [Cacheable(typeof(Book))]
+    public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithMethodNameAsKey(CancellationToken cancellationToken)
+    {
+        var newBook = new Book
+        {
+            Id = 1,
+            Name = "Redis Cache Manager"
+        };
+
+        return Task.FromResult<ActionResult<Book>>(Ok(newBook));
+    }
+
     /// <summary>
     /// if the "book-key" exist in cache, this method will be short-circuiting |
     /// if the response is 200 the content will be persisted in cache with the specified key
@@ -41,7 +54,7 @@ public sealed class MainController : Controller
     /// <returns></returns>
     [HttpGet]
     [Cacheable(typeof(Book), CacheableKeyType.FromProvidedValue, "book-key")]
-    public Task<ActionResult<Book>> GetBookWithCacheManagerAttributeAsync(CancellationToken cancellationToken)
+    public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithProvidedKey(CancellationToken cancellationToken)
     {
         var newBook = new Book
         {
@@ -54,7 +67,7 @@ public sealed class MainController : Controller
 
     [HttpGet("[action]/{bookId}")]
     [Cacheable(typeof(Book), CacheableKeyType.FromRouteOrQuery, "bookId")]
-    public Task<ActionResult<Book>> GetBookByIdFromRoute(int bookId, CancellationToken cancellationToken)
+    public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithKeyFromRoute(int bookId, CancellationToken cancellationToken)
     {
         var newBook = new Book
         {
@@ -64,9 +77,9 @@ public sealed class MainController : Controller
 
         return Task.FromResult<ActionResult<Book>>(Ok(newBook));
     }
-    
+
     [Cacheable(typeof(Book), CacheableKeyType.FromModel, "book.id")]
-    public Task<ActionResult<Book>> GetBookByIdFromModel(Book book, CancellationToken cancellationToken)
+    public Task<ActionResult<Book>> GetBookWithCacheableAttributeWithKeyFromModel(Book book, CancellationToken cancellationToken)
     {
         var newBook = new Book
         {

--- a/Sample/Controllers/MainController.cs
+++ b/Sample/Controllers/MainController.cs
@@ -1,4 +1,5 @@
 ﻿using CacheManager.Redis.Attributes;
+using CacheManager.Redis.Enums;
 using CacheManager.Redis.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
@@ -32,14 +33,45 @@ public sealed class MainController : Controller
         return Ok(newBook);
     }
     
+    /// <summary>
+    /// if the "book-key" exist in cache, this method will be short-circuiting |
+    /// if the response is 200 the content will be persisted in cache with the specified key
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     [HttpGet]
-    [Cacheable(typeof(Book), "book-key")]
+    [Cacheable(typeof(Book), CacheableKeyType.FromProvidedValue, "book-key")]
     public Task<ActionResult<Book>> GetBookWithCacheManagerAttributeAsync(CancellationToken cancellationToken)
     {
         var newBook = new Book
         {
             Id = 1,
             Name = "Redis Cache Manager"
+        };
+
+        return Task.FromResult<ActionResult<Book>>(Ok(newBook));
+    }
+
+    [HttpGet("[action]/{bookId}")]
+    [Cacheable(typeof(Book), CacheableKeyType.FromRouteOrQuery, "bookId")]
+    public Task<ActionResult<Book>> GetBookByIdFromRoute(int bookId, CancellationToken cancellationToken)
+    {
+        var newBook = new Book
+        {
+            Id = bookId,
+            Name = "Sample Book"
+        };
+
+        return Task.FromResult<ActionResult<Book>>(Ok(newBook));
+    }
+    
+    [Cacheable(typeof(Book), CacheableKeyType.FromModel, "book.id")]
+    public Task<ActionResult<Book>> GetBookByIdFromModel(Book book, CancellationToken cancellationToken)
+    {
+        var newBook = new Book
+        {
+            Id = book.Id,
+            Name = "Sample Book"
         };
 
         return Task.FromResult<ActionResult<Book>>(Ok(newBook));

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,7 +1,4 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using CacheManager.Redis.Extensions;
-using Microsoft.Extensions.Caching.Distributed;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -8,27 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\src\CacheManager.Redis\CacheManager.Redis.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Include="obj\Debug\net8.0\.NETCoreApp,Version=v8.0.AssemblyAttributes.cs" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="obj\Debug\net8.0\Sample.AssemblyInfoInputs.cache" />
-      <Content Include="obj\Debug\net8.0\Sample.assets.cache" />
-      <Content Include="obj\Debug\net8.0\Sample.csproj.AssemblyReference.cache" />
-      <Content Include="obj\project.assets.json" />
-      <Content Include="obj\project.nuget.cache" />
-      <Content Include="obj\project.packagespec.json" />
-      <Content Include="obj\rider.project.restore.info" />
-      <Content Include="obj\Sample.csproj.nuget.dgspec.json" />
     </ItemGroup>
 
 </Project>

--- a/src/CacheManager.Redis/CacheManager.Redis.csproj
+++ b/src/CacheManager.Redis/CacheManager.Redis.csproj
@@ -17,20 +17,6 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
-    
-    <ItemGroup>
-      <Content Include="obj\CacheManager.Redis.csproj.nuget.dgspec.json" />
-      <Content Include="obj\Debug\net5.0\CacheManager.Redis.AssemblyInfoInputs.cache" />
-      <Content Include="obj\Debug\net5.0\CacheManager.Redis.assets.cache" />
-      <Content Include="obj\project.assets.json" />
-      <Content Include="obj\project.nuget.cache" />
-      <Content Include="obj\project.packagespec.json" />
-      <Content Include="obj\rider.project.restore.info" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Include="obj\Debug\net5.0\.NETCoreApp,Version=v5.0.AssemblyAttributes.cs" />
-    </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />

--- a/src/CacheManager.Redis/CacheManager.Redis.csproj
+++ b/src/CacheManager.Redis/CacheManager.Redis.csproj
@@ -6,14 +6,18 @@
         <Authors>Aref Nozar</Authors>
         <Description>a generic redis cache manager for .net applications</Description>
         <Nullable>enable</Nullable>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Copyright>https://github.com/arefLA/CacheManager.Redis</Copyright>
         <PackageProjectUrl>https://github.com/arefLA/CacheManager.Redis</PackageProjectUrl>
         <RepositoryUrl>https://github.com/arefLA/CacheManager.Redis</RepositoryUrl>
         <PackageTags>redis, cache manager, generic</PackageTags>
-        <Version>1.2.0</Version>
+        <Version>1.4.0</Version>
     </PropertyGroup>
 
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    
     <ItemGroup>
       <Content Include="obj\CacheManager.Redis.csproj.nuget.dgspec.json" />
       <Content Include="obj\Debug\net5.0\CacheManager.Redis.AssemblyInfoInputs.cache" />
@@ -30,7 +34,7 @@
 
     <ItemGroup>
       <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.30" />
     </ItemGroup>
 
 </Project>

--- a/src/CacheManager.Redis/Enums/CacheableKeyType.cs
+++ b/src/CacheManager.Redis/Enums/CacheableKeyType.cs
@@ -1,0 +1,9 @@
+namespace CacheManager.Redis.Enums;
+
+public enum CacheableKeyType
+{
+    FromRouteOrQuery,
+    FromModel,
+    FromProvidedValue,
+    MethodName
+}

--- a/src/CacheManager.Redis/attributes/CacheableAttribute.cs
+++ b/src/CacheManager.Redis/attributes/CacheableAttribute.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ardalis.GuardClauses;
+using CacheManager.Redis.Enums;
+using CacheManager.Redis.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace CacheManager.Redis.Attributes;
+
+public class CacheableAttribute : TypeFilterAttribute
+{
+    public CacheableAttribute(Type entityType) : 
+        base(typeof(CacheableAttribute<>).MakeGenericType(entityType))
+    {
+    }   
+    
+    public CacheableAttribute(Type entityType, CacheableKeyType keyType, string key) : 
+        base(typeof(CacheableAttribute<>).MakeGenericType(entityType))
+    {
+        var objects = new List<object>
+        {
+            key,
+            keyType
+        };
+
+        Arguments = objects.ToArray();
+    }   
+}
+
+public class CacheableAttribute<TEntity> : IAsyncActionFilter where TEntity : class
+{
+    private readonly IRedisCacheManager<TEntity> _cacheManager;
+    private string _key = string.Empty;
+    private CacheableKeyType _keyType = CacheableKeyType.MethodName;
+
+    public CacheableAttribute(IRedisCacheManager<TEntity> cacheManager)
+        => _cacheManager = cacheManager;
+    
+    public CacheableAttribute(IRedisCacheManager<TEntity> cacheManager, string key, CacheableKeyType keyType)
+    {
+        _cacheManager = cacheManager;
+        _key = key;
+        _keyType = keyType;
+    }
+    
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        Guard.Against.Null(context);
+        Guard.Against.Null(next);
+
+        ProduceKey(context);
+        OnActionExecuting(context);
+        if (context.Result == null)
+        {
+            OnActionExecuted(await next());
+        }
+    }
+            
+    public virtual void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.ModelState.IsValid) return;
+                
+        if (_cacheManager.TryGet(_key, out var cachedBook) && cachedBook is not null)
+            context.Result = new OkObjectResult(cachedBook);
+    }
+            
+    public virtual void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context is not { Canceled: false, HttpContext.Response.StatusCode: 200, Result: not null }) return;
+        
+        var result = ((JsonResult)context.Result).Value;
+        if (result is TEntity entity)
+            _cacheManager.Set(_key!, entity);
+    }
+
+    private void ProduceKey(ActionExecutingContext context)
+    {
+        switch (_keyType)
+        {
+            case CacheableKeyType.FromRouteOrQuery:
+                _key = context.ActionArguments[_key]?.ToString()??"";
+                break;
+            case CacheableKeyType.MethodName:
+                _key = context.ActionDescriptor.DisplayName ?? "";
+                break;
+            case CacheableKeyType.FromModel:
+                var modelNameSplit = _key.Split(".");
+                if (modelNameSplit.Length != 2)
+                    break;
+                var modelName = modelNameSplit[0];
+                var model = context.ActionArguments[modelName];
+                if (model is not null)
+                {
+                    var modelType = model.GetType();
+                    var keyProperty = modelType.GetProperty(modelNameSplit[1]);
+                    if (keyProperty is null)
+                        break;
+                    
+                    _key = keyProperty.GetValue(model)?.ToString()??"";
+                        break;
+                }
+                _key = "";
+                break;
+            case CacheableKeyType.FromProvidedValue:
+            default:
+                break;
+        }
+
+        if (string.IsNullOrWhiteSpace(_key))
+            _key = Guard.Against.Null(context.ActionDescriptor.DisplayName);
+    }
+}

--- a/test/CacheManager.Redis.Tests/Attributes/CacheableAttributeTests.cs
+++ b/test/CacheManager.Redis.Tests/Attributes/CacheableAttributeTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CacheManager.Redis.Attributes;
+using CacheManager.Redis.Enums;
+using CacheManager.Redis.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using NSubstitute;
+using Xunit;
+
+namespace CacheManager.Redis.Tests.Attributes;
+
+public sealed class CacheableAttributeTests
+{
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsFromRouteOrQuery_AndPrefixIsProvided()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.FromRouteOrQuery;
+        var prefix = "testPrefix";
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType, prefix);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+        attribute.GetType().GetProperty("Prefix")?.GetValue(attribute).Should().Be("prefix");
+        
+    }
+    
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsFromRouteOrQuery_AndPrefixNotProvided()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.FromRouteOrQuery;
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+        attribute.GetType().GetProperty("Prefix")?.GetValue(attribute).Should().NotBe(string.Empty);
+    }
+    
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsFromModel_AndPrefixIsProvided()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.FromModel;
+        var prefix = "testPrefix";
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType, prefix);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+        attribute.GetType().GetProperty("Prefix")?.GetValue(attribute).Should().Be(prefix);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsFromModel_AndPrefixNotProvided()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.FromModel;
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+        attribute.GetType().GetProperty("Prefix")?.GetValue(attribute).Should().NotBe(string.Empty);
+    }
+    
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsMethodName()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.MethodName;
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+    }
+    
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenKeyTypeIsProvidedValue()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+        var key = "testKey";
+        var keyType = CacheableKeyType.FromProvidedValue;
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager, key, keyType);
+
+        // Assert
+        attribute.Should().NotBeNull();
+        attribute.Should().BeOfType<CacheableAttribute<object>>();
+        attribute.GetType().GetProperty("Key")?.GetValue(attribute).Should().Be(key);
+        attribute.GetType().GetProperty("KeyType")?.GetValue(attribute).Should().Be(keyType);
+    }
+    
+    [Fact]
+    public void Constructor_ShouldSetKey_WhenNoArgumentsProvided()
+    {
+        // Arrange
+        var cacheManager = Substitute.For<IRedisCacheManager<object>>();
+
+        // Act
+        var attribute = new CacheableAttribute<object>(cacheManager);
+
+        // Assert
+        attribute.Should().NotBeNull();
+    }
+}

--- a/test/CacheManager.Redis.Tests/CacheManager.Redis.Tests.csproj
+++ b/test/CacheManager.Redis.Tests/CacheManager.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/CacheManager.Redis.Tests/Extensions/SetupTests.cs
+++ b/test/CacheManager.Redis.Tests/Extensions/SetupTests.cs
@@ -34,7 +34,7 @@ namespace CacheManager.Redis.Tests.Extensions
             AddRedisCacheManager_ShouldAddRedisCacheManagerAsScoped_WhenCalledOnAServiceCollection()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
+            var serviceCollection = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
             
             // Act
             serviceCollection.AddRedisCacheManager("connectionString");


### PR DESCRIPTION
The Cacheable attributes now support an optional prefix parameter. To prevent key collisions and ensure uniqueness, when using FromModel or FromRouteOrQuery key types, if a prefix is not explicitly provided, the system will automatically use the ActionDescriptor.DisplayName as the prefix for the cache key.