### PR TITLE
fix gitignore and commit agent-os scaffolding (N-4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@
 /test/CacheManager.Redis.Tests/bin/
 /test/CacheManager.Redis.Tests/obj/
 /artifacts/
-/docs/
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CacheManager.Redis — Claude Context
+
+## What this repo is
+
+A .NET Redis caching helper library. Source in `src/`, tests in `test/`, sample ASP.NET Core app in `Sample/`, docs in `docs/`. NuGet package ID: `CacheManager.Redis`. Current version: 2.1.1.
+
+Key files:
+- `src/CacheManager.Redis/Interfaces/IRedisCacheManager.cs` — public interface
+- `src/CacheManager.Redis/Services/RedisCacheManager.cs` — implementation
+- `src/CacheManager.Redis/Extensions/Setup.cs` — DI registration
+- `src/CacheManager.Redis/RedisCacheMangerOptions.cs` — configuration options
+- `src/CacheManager.Redis/CacheManager.Redis.csproj` — package metadata and version
+- `src/CacheManager.Redis/README.md` — NuGet package README (distinct from root README)
+- `CHANGELOG.md` — version history
+- `docs/agent-os/BACKLOG.md` — task backlog (read by Orchestrate mode)
+
+## Agent OS
+
+This repo uses Agent OS v1. Read the spec before starting any work session:
+
+**`docs/agent-os/AGENT-OS.md`** — complete specification  
+**`docs/agent-os/README.md`** — quick-start reference
+
+## How to start a session
+
+State your mode and task at the top of your first message:
+
+```
+Mode: [Orchestrate | Explore | Investigate | Build | Release | Content]
+Task: <what you want done>
+Context: <any relevant background>
+```
+
+**Default mode if unspecified: Explore. No file edits in Explore.**
+
+## Mode summary
+
+| Mode | Use for | Can edit files? |
+|---|---|---|
+| Orchestrate | Task backlog management, workflow coordination | Yes — docs/agent-os/BACKLOG.md only |
+| Explore | Understanding, mapping, questions | No |
+| Investigate | Bug/behavior analysis, produces Investigation Note + Implementation Plan | Yes — docs/agent-os/runs/ only |
+| Build | Implementing approved changes | Yes — src/, test/, Sample/ only |
+| Release | Version bump, pack, publish | Yes — .csproj, CHANGELOG.md, CLAUDE.md |
+| Content | Docs, samples, SEO articles | Yes — docs/, README.md, Sample/ |
+
+## Hard rules (always active, regardless of mode)
+
+- No git push, gh release, or dotnet nuget push without explicit per-action confirmation.
+- Show the exact command before running any state-changing operation (git add, git commit, git tag, git push, dotnet pack, dotnet nuget push, gh release create).
+- Build mode requires an approved Implementation Plan before any code changes.
+- Release mode requires a completed Release Checklist before proceeding.
+- NuGet publish requires the GitHub release to be live first.
+- SEO and documentation content must only describe features that exist in the released package.
+- If a gate condition fails, stop and state which condition is unmet. Do not suggest bypassing the gate.
+
+## Branch model
+
+All work starts on `dev`. PRs target `main`. Release mode runs only after the PR is merged and `main` HEAD is the merged feature commit, not stale. Do not run Release mode from `dev`.
+
+## Artifacts
+
+Session artifacts (investigation notes, plans, verification notes) are saved in `docs/agent-os/runs/` using the naming convention:
+
+```
+YYYY-MM-DD-<slug>-<type>.md
+```
+
+Examples: `2026-04-12-null-key-bug-investigation.md`, `2026-04-12-async-overload-plan.md`

--- a/docs/agent-os/AGENT-OS.md
+++ b/docs/agent-os/AGENT-OS.md
@@ -1,0 +1,846 @@
+# CacheManager.Redis Agent OS v1
+
+---
+
+## What This Is
+
+Agent OS v1 is the operating specification for working on CacheManager.Redis with Claude as an agentic coding partner. It defines how Claude should behave across all types of work in this repository: engineering, testing, documentation, and release.
+
+This is not an automation framework. It does not run autonomously. A human reviews and approves all significant outputs before they are committed, published, or released.
+
+This is a discipline spec. Its purpose is to prevent sloppy changes, ensure consistency across sessions, make release work repeatable, and give Claude enough structure to operate without constant correction.
+
+---
+
+## Design Principles
+
+**Separation before action.** Investigation is separate from implementation. Implementation is separate from release. Do not combine modes in one step unless explicitly instructed.
+
+**Artifacts first.** Every significant action produces a written artifact before work begins. No code changes without an Implementation Plan. No release without a Release Checklist. This creates a review trail and forces thinking before typing.
+
+**Small surface, real guardrails.** This repo is small. The OS is small. But lightweight does not mean permissive. The gating rules are real and must be followed even when they feel like overhead.
+
+**Technical honesty.** All content—documentation, samples, SEO articles—must reflect actual package behavior. No invented benchmarks. No fake capability claims. No roadmap promises without explicit marking.
+
+**Human gates real risk.** Claude does not push, publish, or release without explicit human confirmation. File edits and local commands are pre-approved. External actions (git push, NuGet publish, GitHub release) require explicit instruction each time. For any state-changing command (`git add`, `git commit`, `git tag`, `git push`, `dotnet pack`, `dotnet nuget push`, `gh release create`), Claude shows the exact command before running it.
+
+---
+
+## Operating Model
+
+Agent OS v1 uses a **mode-based** model. Each session has one active mode. Modes enforce behavioral boundaries — what Claude is allowed to read, write, and run.
+
+State the mode and task at the start of every session. Claude enters that mode and stays in it. Switching modes requires an explicit instruction.
+
+**To start a session:**
+```
+Mode: [Orchestrate | Explore | Investigate | Build | Release | Content]
+Task: <what you want done>
+Context: <any relevant background or links>
+```
+
+If no mode is specified, Claude defaults to **Explore** and will not make changes.
+
+## Branch Model
+
+All development work happens on `dev`. PRs target `main`. When a PR is merged:
+
+- `main` receives the changes
+- Release mode runs **only from `main`** after the merge
+
+Do not run Release mode from `dev`. Do not bump the version on `dev`.
+
+---
+
+## Modes
+
+### Mode: Orchestrate
+
+**Purpose:** Read the task backlog, select a task, determine the appropriate mode and workflow, and manage execution end-to-end — stopping at every gate for human verification.
+
+**Allowed to:**
+- Read any file in the repo
+- Read and update `docs/agent-os/BACKLOG.md` (task status and artifact links only)
+- Suggest which mode and workflow to apply to a selected task
+- Transition into another mode after human confirmation
+
+**Not allowed to:**
+- Skip any gate rule belonging to the delegated mode
+- Edit source files, README, or `.csproj` directly (those belong to the delegated mode)
+- Start a task without human confirmation of the approach
+- Mark a task complete without human confirmation
+
+**Required input:** `docs/agent-os/BACKLOG.md` with at least one pending task, or a task provided inline by the human.
+
+**Output:** Updated `BACKLOG.md` status + all artifacts produced by the delegated mode.
+
+**Handoff:** After completing a task, return to the backlog and ask whether to continue with the next task or stop.
+
+---
+
+### Mode: Explore
+
+**Purpose:** Understand the codebase. Answer structural and behavioral questions. Map dependencies. Identify where things live.
+
+**Allowed to:**
+- Read any file in the repo
+- Run `dotnet build` (to confirm build state), `grep`, `find`, `git log`, `git diff`
+- Produce a written summary or map
+
+Explore mode runs read-only and non-state-changing local validation commands only.
+
+**Not allowed to:**
+- Edit any file
+- Run `dotnet test` (use Investigate mode if test output is needed)
+- Begin implementation or produce an Implementation Plan
+- Switch modes unilaterally
+- Run `dotnet pack`, push to git, or touch external systems
+
+Explore may flag likely bugs, design issues, or improvement opportunities, but must stop short of proposing implementation details.
+
+**Required input:** A question or area to explore.
+
+**Output:** A concise written summary. If the user asks for a structured note, produce an Exploration Summary using the template at `docs/agent-os/templates/exploration-summary.md`.
+
+**Handoff:** If exploration reveals a bug or opportunity, say so and stop. Do not automatically switch to Investigate. Wait for instruction.
+
+---
+
+### Mode: Investigate
+
+**Purpose:** Investigate a specific bug, behavior, or proposed change. Produce an Investigation Note and optionally an Implementation Plan.
+
+**Allowed to:**
+- Everything Explore allows
+- Run targeted tests, add temporary debug output to understand behavior
+- Read test cases, inspect serialization behavior, trace call paths
+
+**Not allowed to:**
+- Commit any changes
+- Make permanent edits to source files (the only file writes allowed are saving Investigation Notes and Implementation Plans to `docs/agent-os/runs/`)
+- Leave temporary diagnostic edits in source files — any temporary debug output added during investigation must be removed before the session ends
+- Open PRs or create issues
+
+**Required input:** A specific bug report, behavior question, or enhancement idea.
+
+**Output:**
+1. An Investigation Note (see Templates) — always required
+2. An Implementation Plan (see Templates) — required if the investigation concludes with actionable changes
+
+**Handoff:** After producing the Implementation Plan, stop and wait for approval before switching to Build.
+
+---
+
+### Mode: Build
+
+**Purpose:** Implement approved changes. This includes bug fixes, features, refactors, tests, and samples.
+
+**Allowed to:**
+- Edit source files in `src/`, `test/`, `Sample/`
+- Update `README.md`, `src/CacheManager.Redis/README.md`, and `docs/` when required to keep public documentation accurate with implemented behavior changes (new public methods, changed options, changed setup, changed exceptions)
+- Run `dotnet build` and `dotnet test`
+- Create new files within established patterns
+
+**Not allowed to:**
+- Perform unrelated documentation rewrites, restructuring, or cleanup not required by the implemented behavior
+- Bump version numbers (that belongs to Release)
+- Push to git
+- Merge branches
+- Change `.csproj` metadata (description, tags, version) — defer to Release
+- Run `dotnet build -c Release` — this triggers `GeneratePackageOnBuild` and produces an unvalidated `.nupkg` in `bin/`. Use `dotnet build` (Debug) during Build mode.
+
+**Required input:** An approved Implementation Plan. Build mode must not start without one.
+
+**What counts as a "non-trivial change" requiring an Investigation Note and Implementation Plan:**
+- Any public API or interface change
+- Any behavior change affecting cache semantics, serialization, key generation, expiration, or the `[Cacheable]` attribute
+- Any change to DI registration behavior
+- Any new file in `src/` or a new test suite in `test/`
+- Any refactor touching multiple classes or layers
+
+**What does NOT require a full plan (inline description in the session is sufficient):**
+- Typo or comment fixes
+- Whitespace or formatting corrections
+- Localized one-line bug fixes with an obvious cause and no API impact (e.g., a wrong null check, a missing guard)
+- Test-only additions that do not require behavior changes in `src/`
+
+**Output:**
+1. Working code that passes `dotnet test`
+2. A Verification Note confirming what was tested and how (see Templates)
+
+**Handoff:** After producing the Verification Note, stop. Do not automatically proceed to Release.
+
+---
+
+### Mode: Release
+
+**Purpose:** Prepare and execute a release. This covers version bumping, changelog, pack, GitHub release, and NuGet publish.
+
+**Allowed to:**
+- Edit version in `.csproj`
+- Edit `CHANGELOG.md`
+- Edit `CLAUDE.md` (version number update)
+- Run `dotnet pack`
+- Validate the `.nupkg` artifact
+- Produce the GitHub release body
+- Run `dotnet nuget push` when explicitly confirmed
+
+**Not allowed to:**
+- Make feature changes or fix bugs (that's Build)
+- Push to git or run `gh release create` without explicit human confirmation per action
+- Publish to NuGet without explicit human confirmation per publish
+
+**Required input:** A completed Verification Note from Build, a Release Checklist (see Templates), and explicit instruction to start.
+
+**Output:**
+1. Version bump commit
+2. Updated `CHANGELOG.md`
+3. Validated `.nupkg`
+4. GitHub release body draft
+5. Post-release verification note
+
+**Handoff:** After each external action (push, gh release, nuget push), stop and report status. Do not chain external actions without confirmation.
+
+---
+
+### Mode: Content
+
+**Purpose:** Write documentation, samples, SEO articles, and release notes.
+
+**Allowed to:**
+- Create and edit files in `docs/`, `Sample/`, `src/CacheManager.Redis/README.md`
+- Edit the main `README.md`
+- Produce markdown drafts for review
+
+**Not allowed to:**
+- Fabricate benchmarks, invent capabilities, or make roadmap claims without explicit marking
+- Edit source code in `src/` or `test/`
+- Publish content to external platforms
+
+**Required input:** A task description specifying the content type, audience, and scope.
+
+**Two content classes:**
+
+1. **Product documentation** — `README.md`, `src/CacheManager.Redis/README.md`, `docs/`, `Sample/`. Must reflect actual package behavior exactly. No simplification that introduces inaccuracy.
+2. **Marketing and SEO content** — articles, tutorials, comparison posts, release summaries. May simplify structure for readability but must remain technically accurate. Subject to the Marketing and SEO rules in this spec.
+
+**Output:** A markdown draft. For SEO articles, also produce an SEO Article Brief (see Templates) before writing.
+
+**Handoff:** All content must be reviewed by the human before being committed. Claude flags any claims it is unsure about.
+
+---
+
+## Workflow Catalog
+
+### W-00: Orchestrate Workflow
+
+1. Enter **Orchestrate** mode.
+2. Read `docs/agent-os/BACKLOG.md`. Present pending tasks.
+3. Human selects a task (or confirms the top priority item).
+4. Determine starting mode and workflow from the task type → mode mapping in `workflows/orchestrate.md`.
+5. Confirm the approach with the human before starting.
+6. Update task status to `in-progress` in `BACKLOG.md`.
+7. Execute in the delegated mode, following all gates and gating rules.
+8. Mark task `complete` in `BACKLOG.md` when done. Return to backlog.
+
+---
+
+### W-01: Repo Exploration
+
+1. Enter **Explore** mode.
+2. Read the directory structure, `.csproj`, key interfaces, and `README.md`.
+3. If asked for a map, produce an Exploration Summary.
+4. Stop. Do not infer tasks.
+
+---
+
+### W-02: Investigation Before Implementation
+
+1. Enter **Investigate** mode with a clear question or bug report.
+2. Read relevant source, tests, and history.
+3. Reproduce or confirm the behavior.
+4. Write the Investigation Note.
+5. If changes are warranted, write the Implementation Plan.
+6. Stop. Wait for approval.
+
+---
+
+### W-03: Bug Investigation and Fix
+
+1. **Investigate** mode: reproduce the bug, trace the root cause, write Investigation Note.
+2. Get approval on the Investigation Note.
+3. Write Implementation Plan (scope: minimal fix only, no unrelated cleanup).
+4. Get approval on the Implementation Plan.
+5. **Build** mode: implement the fix, run `dotnet test`, write Verification Note.
+6. Human reviews diff and Verification Note.
+7. Commit on human instruction.
+
+---
+
+### W-04: Enhancement Proposal
+
+1. **Investigate** mode: research what exists, what is missing, and whether the enhancement fits the library's scope.
+2. Write Investigation Note covering: current behavior, gap, proposed behavior, interface changes, breaking change risk.
+3. Write Implementation Plan only if the human approves the direction.
+4. Proceed to **Build** only after plan approval.
+
+---
+
+### W-05: Refactor Workflow
+
+1. **Investigate** mode: identify what is being refactored and why. Write Investigation Note.
+2. Implementation Plan must explicitly list:
+   - Files touched
+   - Public API changes (none expected in a safe refactor)
+   - Test coverage before and after
+3. **Build** mode: make changes, ensure tests still pass, write Verification Note.
+4. Do not refactor beyond the stated scope.
+
+---
+
+### W-06: Implementation Workflow
+
+1. Confirm Implementation Plan is approved.
+2. **Build** mode: follow the plan in order. Do not scope-creep.
+3. After each logical unit (not necessarily each file), run `dotnet test`.
+4. Write Verification Note when complete.
+5. Do not bump version, update changelog, or modify `.csproj` metadata during Build.
+
+---
+
+### W-07: Test-Writing Workflow
+
+1. **Investigate** mode: identify what is untested or under-tested.
+2. Write brief Implementation Plan: which behaviors, which test classes, which scenarios.
+3. **Build** mode: write tests. Follow existing patterns in `test/CacheManager.Redis.Tests/`.
+4. All new tests must pass. No skipped tests without explanation.
+5. Verification Note: list each new test method and what it asserts.
+
+---
+
+### W-08: Sample-Writing Workflow
+
+1. **Content** mode.
+2. Samples live in `Sample/`. Follow the existing ASP.NET Core structure.
+3. Every sample must compile and run against the current package.
+4. Do not invent sample scenarios that require unreleased features.
+5. Verify the sample builds: `dotnet build Sample/`.
+
+---
+
+### W-09: Documentation-Writing Workflow
+
+1. **Content** mode.
+2. For package-level docs (README embedded in NuGet), edit `src/CacheManager.Redis/README.md`.
+3. For repo README, edit the root `README.md`.
+4. For standalone guides, create files in `docs/`.
+5. All API usage in docs must match current interfaces in `src/CacheManager.Redis/Interfaces/`.
+6. Verify accuracy by reading the interface before writing.
+
+---
+
+### W-10: SEO Article / Technical Marketing Content Workflow
+
+1. **Content** mode.
+2. Start with an SEO Article Brief (see Templates). Get approval before writing.
+3. Write the article. Every code sample must work against the actual package.
+4. Apply SEO discipline rules (see Marketing and SEO section).
+5. Output goes to `docs/`. Human reviews before publishing anywhere.
+
+---
+
+### W-11: Release Note / Changelist Workflow
+
+1. Stay in **Release** mode. No need to switch to Content. Release mode can edit `CHANGELOG.md` and produce the GitHub release body draft.
+2. Run `git log <previous-tag>..HEAD --oneline` to get the commit list.
+3. Group commits using the changelog template headings: **Added**, **Changed**, **Fixed**, **Internal**.
+4. Write the changelog entry in `CHANGELOG.md` using the template.
+5. Write the GitHub release body (same content, formatted for GitHub).
+6. Human reviews before it is attached to a release.
+
+---
+
+### W-12: Package Workflow
+
+1. **Release** mode.
+2. Confirm Release Checklist is complete.
+3. Confirm version in `.csproj` matches the intended release version.
+4. Run `dotnet pack src/CacheManager.Redis/CacheManager.Redis.csproj -c Release -o ./artifacts`.
+5. Inspect the `.nupkg` contents: confirm version, README, and dependencies are correct.
+6. Write Package Validation Note.
+7. Stop and report. Do not publish without instruction.
+
+---
+
+### W-13: GitHub Release Workflow
+
+1. **Release** mode.
+2. Confirm the `.nupkg` has been validated.
+3. Confirm the changelog entry is written.
+4. Confirm the tag exists: `git tag -l v<version>` — must output the tag name.
+5. Push the release commit and tag: `git push origin main` then `git push origin v<version>` — each requires explicit confirmation.
+6. Create the GitHub release using `gh release create v<version>` with the release body — requires explicit confirmation.
+7. Verify the release appears at `https://github.com/arefLA/CacheManager.Redis/releases`.
+
+---
+
+### W-14: NuGet Publish Workflow
+
+1. **Release** mode.
+2. Confirm the GitHub release is live.
+3. Confirm the `.nupkg` path.
+4. Run `dotnet nuget push` — requires explicit confirmation with the API key.
+5. Verify the package appears on NuGet at `https://www.nuget.org/packages/CacheManager.Redis`.
+6. Write post-publish verification note.
+
+---
+
+## Gating Rules
+
+### Before Build starts:
+
+- [ ] Investigation Note exists and has been reviewed
+- [ ] Implementation Plan exists and has been explicitly approved
+- [ ] The plan does not include scope beyond what was approved
+
+### Before Release starts:
+
+- [ ] PR from `dev` to `main` is merged
+- [ ] Currently on `main` (`git branch --show-current`)
+- [ ] Working tree is clean — no uncommitted changes outside intended release metadata files
+- [ ] `./artifacts/` is empty or absent — no stale `.nupkg` from a prior run
+- [ ] `dotnet test` passes with no failures
+- [ ] Verification Note exists for the changes being released
+- [ ] Changelog entry has been drafted
+- [ ] Version number has been agreed (no automatic bumps)
+- [ ] `CLAUDE.md` version updated to the new version number
+- [ ] README accurately describes the release version's features
+
+### Before NuGet publish:
+
+- [ ] GitHub release is live with the correct tag
+- [ ] Package Validation Note has been written and saved to `runs/`
+- [ ] `.nupkg` has been locally validated (version, contents, dependencies)
+- [ ] Package README matches the source README
+- [ ] Human has confirmed the publish command
+
+### Gate failure rule
+
+If a gate condition is not met, Claude must:
+1. Stop immediately.
+2. State which specific condition is unmet.
+3. Not suggest bypassing the gate unless the human explicitly requests a change to the spec.
+
+---
+
+## Artifact Definitions
+
+### Investigation Note
+
+**Purpose:** Record what was found during investigation. Inputs for the Implementation Plan.
+
+**Required contents:**
+- Task or bug ID/title
+- What was investigated (files, methods, test cases)
+- What was found (root cause or gap)
+- Reproduction steps if a bug
+- Risk surface (what else could be affected)
+
+**When required:** Before any Implementation Plan is written.
+
+**Who produces it:** Claude in Investigate mode.
+
+---
+
+### Implementation Plan
+
+**Purpose:** Define exactly what will be changed before any code is written.
+
+**Required contents:**
+- Problem statement (one sentence)
+- Proposed solution (concrete, not abstract)
+- Files to be changed
+- New files to be created (if any)
+- Public API changes (or confirmation there are none)
+- Test plan: what new tests are needed
+- Out of scope (explicit list of what is NOT being done)
+
+**When required:** Before Build mode starts for any non-trivial change.
+
+**Who produces it:** Claude in Investigate mode, approved by the human.
+
+---
+
+### Verification Note
+
+**Purpose:** Confirm that what was built matches what was planned and that tests pass.
+
+**Required contents:**
+- Reference to the Implementation Plan
+- Summary of changes made
+- Test results (`dotnet test` output summary)
+- Any deviations from the plan and why
+- Known gaps or follow-up items
+
+**When required:** After every Build session, before Release can start.
+
+**Who produces it:** Claude in Build mode.
+
+---
+
+### Release Checklist
+
+**Purpose:** Gate the release. No release proceeds without this being complete.
+
+**Required contents:** See template.
+
+**When required:** At the start of every Release mode session.
+
+**Who produces it:** Claude in Release mode, confirmed by human.
+
+---
+
+### Package Validation Note
+
+**Purpose:** Confirm the `.nupkg` is correct before publish.
+
+**Required contents:**
+- Package ID confirmed: `CacheManager.Redis`
+- Version number confirmed
+- Target frameworks confirmed
+- README included and correct
+- Dependencies list confirmed
+- No stale build artifacts
+
+**When required:** After `dotnet pack`, before push or publish.
+
+**Who produces it:** Claude in Release mode.
+
+---
+
+### Changelog Entry
+
+**Purpose:** Human-readable record of changes in a version.
+
+**Required contents:** See template.
+
+**When required:** For every release.
+
+**Who produces it:** Claude in Release mode.
+
+---
+
+### SEO Article Brief
+
+**Purpose:** Align on topic, target keywords, and factual constraints before writing.
+
+**Required contents:** See template.
+
+**When required:** Before any SEO or marketing article is written.
+
+**Who produces it:** Claude in Content mode, approved by human before article writing begins.
+
+---
+
+## Suggested Repository Structure
+
+```
+CLAUDE.md                        ← session bootstrap (read automatically by Claude Code)
+CHANGELOG.md                     ← version history
+docs/
+├── agent-os/
+│   ├── AGENT-OS.md              ← this file (main spec)
+│   ├── README.md                ← quick-start reference
+│   ├── BACKLOG.md               ← task backlog (read by Orchestrate mode)
+│   ├── runs/                    ← session artifacts (committed)
+│   │   └── YYYY-MM-DD-<slug>-<type>.md
+│   ├── workflows/               ← detailed procedure for each workflow
+│   │   ├── orchestrate.md       ← W-00
+│   │   ├── explore.md           ← W-01
+│   │   ├── investigate.md       ← W-02
+│   │   ├── bug-fix.md           ← W-03
+│   │   ├── enhance.md           ← W-04
+│   │   ├── refactor.md          ← W-05
+│   │   ├── implement.md         ← W-06
+│   │   ├── test.md              ← W-07
+│   │   ├── sample.md            ← W-08
+│   │   ├── docs-writing.md      ← W-09
+│   │   ├── seo-content.md       ← W-10
+│   │   ├── release-notes.md     ← W-11
+│   │   ├── package.md           ← W-12
+│   │   ├── github-release.md    ← W-13
+│   │   └── nuget-publish.md     ← W-14
+│   └── templates/               ← artifact templates (fill in per session)
+│       ├── task-entry.md
+│       ├── exploration-summary.md
+│       ├── investigation-note.md
+│       ├── implementation-plan.md
+│       ├── verification-note.md
+│       ├── release-checklist.md
+│       ├── changelog-entry.md
+│       └── seo-article-brief.md
+└── redis-cache-dotnet-guide.md  ← existing SEO article
+```
+
+### `runs/` naming convention
+
+Every artifact saved to `runs/` must follow this pattern:
+
+```
+YYYY-MM-DD-<slug>-<type>.md
+```
+
+Types: `investigation`, `plan`, `verification`, `release-checklist`, `package-validation`, `post-release`, `task`, `explore`
+
+Examples:
+```
+2026-04-12-null-key-handling-investigation.md
+2026-04-12-add-remove-overload-plan.md
+2026-04-12-add-remove-overload-verification.md
+2026-02-13-v2.1.1-release-checklist.md
+2026-02-13-v2.1.1-package-validation.md
+2026-04-12-initial-codebase-explore.md
+```
+
+Artifacts in `runs/` are committed to the repo. They are the audit trail.
+
+---
+
+## Templates
+
+Templates live in `docs/agent-os/templates/`. Each template is its own file — use those files directly. Do not edit the templates themselves; copy the contents into a new file in `runs/` for each session.
+
+| Template file | When to use |
+|---|---|
+| [`task-entry.md`](templates/task-entry.md) | Every Investigate, Build, Release, and Content session; optional for Explore |
+| [`exploration-summary.md`](templates/exploration-summary.md) | When an Explore session produces a structured output |
+| [`investigation-note.md`](templates/investigation-note.md) | Every Investigate session |
+| [`implementation-plan.md`](templates/implementation-plan.md) | Before every Build session |
+| [`verification-note.md`](templates/verification-note.md) | After every Build session |
+| [`release-checklist.md`](templates/release-checklist.md) | Every Release session |
+| [`changelog-entry.md`](templates/changelog-entry.md) | Every release |
+| [`seo-article-brief.md`](templates/seo-article-brief.md) | Before every SEO article |
+
+---
+
+## Release Workflow
+
+This is the authoritative release procedure. Follow it in order. Do not skip steps.
+
+**All steps in this workflow happen on `main` after the PR from `dev` is merged.** Do not start any step — including the version bump and changelog — while on `dev`. The PR should contain only the feature/fix work. Release prep (version bump, changelog, README verify, pack) is a separate commit on `main`.
+
+### Step 1: Confirm readiness
+
+Run the Release Checklist. All pre-release items must be checked before proceeding.
+
+```bash
+dotnet test
+# Must output: X passed, 0 failed
+```
+
+### Step 2: Bump version
+
+Edit `src/CacheManager.Redis/CacheManager.Redis.csproj`:
+```xml
+<Version>X.Y.Z</Version>
+```
+
+Follow semantic versioning:
+- Patch (X.Y.**Z**): bug fixes only
+- Minor (X.**Y**.0): new non-breaking functionality
+- Major (**X**.0.0): breaking API changes
+
+### Step 3: Update changelog
+
+Add entry to `CHANGELOG.md` at the root. Use the changelog template.
+
+### Step 4: Verify README accuracy
+
+- Root `README.md`: confirm all code samples work with the new version
+- `src/CacheManager.Redis/README.md`: confirm it matches what ships in the NuGet package
+- Check that `<Version>` in `.csproj` matches what README says about current version
+
+### Step 5: Verify sample
+
+```bash
+dotnet build Sample/Sample.csproj
+```
+
+If the sample references a local package path, confirm the reference is correct.
+
+### Step 6: Pack
+
+Note: `CacheManager.Redis.csproj` has `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>`, which means `dotnet build -c Release` already produces a `.nupkg` in `bin/`. Use the explicit `dotnet pack` command below to produce a clean artifact in `./artifacts` instead, and always use this path for publishing — never the `bin/` output.
+
+```bash
+dotnet pack src/CacheManager.Redis/CacheManager.Redis.csproj -c Release -o ./artifacts
+```
+
+Inspect the output:
+```bash
+# Verify version, README, and target frameworks inside the .nupkg
+unzip -l ./artifacts/CacheManager.Redis.X.Y.Z.nupkg
+```
+
+Write the Package Validation Note.
+
+### Step 7: Commit and tag
+
+This step runs on `main` after the PR from `dev` is merged. Confirm you are on `main`:
+
+```bash
+git branch --show-current  # must be: main
+```
+
+```bash
+git add src/CacheManager.Redis/CacheManager.Redis.csproj src/CacheManager.Redis/README.md CHANGELOG.md README.md CLAUDE.md
+git commit -m "release: v<version>"
+git tag vX.Y.Z
+```
+
+**Stop. Human confirms before push.**
+
+### Step 8: Push release commit and tag
+
+Step 7 created a new commit on `main` (version bump, changelog, README, CLAUDE.md). Push the branch, then push the tag. Each requires explicit confirmation.
+
+```bash
+git push origin main
+```
+
+**Requires explicit confirmation.**
+
+```bash
+git push origin vX.Y.Z
+```
+
+**Requires explicit confirmation.**
+
+### Step 9: GitHub release
+
+```bash
+gh release create vX.Y.Z ./artifacts/CacheManager.Redis.X.Y.Z.nupkg \
+  --title "vX.Y.Z" \
+  --notes-file <changelog-entry-file>
+```
+
+**Requires explicit confirmation.**
+
+### Step 10: NuGet publish
+
+```bash
+dotnet nuget push ./artifacts/CacheManager.Redis.X.Y.Z.nupkg \
+  --api-key $NUGET_API_KEY \
+  --source https://api.nuget.org/v3/index.json
+```
+
+**Requires explicit confirmation. Never hardcode the API key.**
+
+### Step 11: Post-release verification
+
+- Confirm NuGet page shows the new version (may take a few minutes)
+- Confirm package README renders correctly on NuGet
+- Confirm GitHub releases page is correct
+- Write post-release note in `docs/agent-os/runs/`
+
+---
+
+## Marketing and SEO Workflow
+
+### Purpose
+
+Produce technical content that helps .NET developers find and use CacheManager.Redis. The content must be accurate, useful, and grounded in what the package actually does.
+
+### Rules
+
+**Truth first.**
+- Every code sample must compile and run against the stated package version.
+- Do not claim performance numbers unless you have measured them in a reproducible way and can cite the conditions.
+- Do not describe features that do not exist in the released package.
+- If a feature is planned but not shipped, mark it explicitly: `(planned for v3.0)`.
+
+**No inflation.**
+- Do not describe the package as "enterprise-grade", "battle-tested", or similar unless you have evidence.
+- Do not compare against other packages (StackExchange.Redis, EasyCaching, etc.) unless the comparison is accurate, fair, and you have tested both.
+- Do not invent user quotes or testimonials.
+
+**SEO discipline.**
+- Target one primary keyword per article. Do not stuff secondary keywords unnaturally.
+- The keyword must appear in the title, the first paragraph, at least one H2, and the meta description.
+- Do not write articles whose only purpose is to rank — every article must genuinely help a developer solve a problem.
+
+**Article brief required.**
+- Every SEO article starts with an approved brief. No exceptions.
+- The brief defines the factual constraints before writing begins.
+
+**What good SEO content looks like for this package:**
+- "How to use Redis caching in ASP.NET Core" — with real code using CacheManager.Redis
+- "Strongly-typed Redis cache in .NET with System.Text.Json" — explains the serialization model
+- "Reducing Redis boilerplate in .NET 8" — compares before/after, factual
+- "IRedisCacheManager vs IDistributedCache" — honest comparison, both have trade-offs
+
+**What to avoid:**
+- "Why CacheManager.Redis is the best Redis library" (superlative, unprovable)
+- "10x faster than raw Redis" (invented benchmark)
+- "Used by thousands of developers" (unverifiable claim)
+
+---
+
+## v1 Boundaries
+
+Agent OS v1 explicitly does not cover:
+
+- **No autonomous operation.** Claude does not run, publish, or push anything without a human in the loop.
+- **No issue triage.** Claude does not read or respond to GitHub issues autonomously.
+- **No social media.** No Twitter/X, LinkedIn, or other posting.
+- **No external monitoring.** No NuGet download stats, no GitHub traffic analysis.
+- **No multi-repo work.** This OS applies only to the CacheManager.Redis repository.
+- **No background jobs.** All sessions are synchronous and human-initiated.
+- **No CI/CD integration.** No GitHub Actions workflows are defined or modified by this OS.
+- **No automatic dependency updates.** Dependency bumps go through Build mode with an Investigation Note.
+- **No hidden git operations.** Every git command is shown and confirmed before running.
+- **No automatic branch management.** Claude does not create, merge, or delete branches without instruction.
+
+These are v2 candidates, not omissions.
+
+---
+
+## Recommended First Iteration Plan
+
+The following tasks were completed during Agent OS v1 setup. They are recorded here for reference.
+
+1. ~~**Commit this spec.**~~ Done — `docs/agent-os/` is committed.
+
+2. ~~**Write the initial `CHANGELOG.md`.**~~ Done — `CHANGELOG.md` is backfilled through v2.1.1.
+
+3. **Run an initial Explore session.** Not yet done. Run Mode: Explore to produce a codebase map and save it to `docs/agent-os/runs/YYYY-MM-DD-initial-explore.md`. This gives future sessions a starting point without re-deriving structure.
+
+4. **Dry-run the Release Checklist against v2.1.1.** Not to re-release, but to find any gaps in the checklist before the next real release. Mark any failures as follow-up tasks.
+
+5. **Run one real task end-to-end.** Pick one thing — a missing test, a small bug, a doc gap — and run it through: Investigate → Build → Content (if docs need updating). This validates that the OS works in practice, not just on paper.
+
+---
+
+## Design Rationale
+
+**Why 6 modes.**
+
+The work in this repo falls into two concerns: writing code and writing words. Explore and Investigate are pre-work for writing code. Build is the execution. Release is deployment. Content covers everything text-based. Orchestrate sits above all of them — it is the task coordination layer that reads the backlog, selects work, and manages mode transitions without bypassing any gate. Six modes cover the full surface. Any fewer and the separation between investigation and implementation would collapse; removing Orchestrate would put all task selection and sequencing on the human with no structured support.
+
+**Why modes in one conversation, not separate agents.**
+
+Separate agents add context switching cost and cold-start overhead. In a small repo worked on by one person, the value of isolated agents is low. Modes within a single conversation preserve context while still enforcing behavioral boundaries. The mode constraint is behavioral, enforced by convention — not by a runtime.
+
+**Why this is not overengineered.**
+
+The spec is one main file, fourteen workflow docs, eight templates, and a `CLAUDE.md` bootstrap. It has no configuration format, no DSL, no agent registry, no orchestration graph. It works by convention and instruction. A senior developer can read the whole thing in twenty minutes and start using it the same day. That is the right level of complexity for a package at this size and stage.
+
+**What can be added in v2.**
+
+If the repo grows — multiple contributors, more complex release branching, CI integration, or a documentation site — v2 additions could include:
+
+- GitHub Actions hooks that enforce artifact presence before merge
+- An automated changelog generator (still human-reviewed)
+- A dedicated `docs-site` workflow if a documentation site is added
+- Issue triage rules if the issue volume grows
+- A `CONTRIBUTING.md` that references this OS for contributors

--- a/docs/agent-os/BACKLOG.md
+++ b/docs/agent-os/BACKLOG.md
@@ -1,0 +1,100 @@
+# Task Backlog
+
+All pending work for CacheManager.Redis is tracked here. Orchestrate mode reads this file to select and sequence tasks.
+
+**Task types:** `bug` | `feature` | `investigate` | `refactor` | `test` | `docs` | `sample` | `content` | `release`  
+**Priority:** `high` | `medium` | `low`  
+**Status:** `pending` | `in-progress` | `complete` | `blocked`
+
+**ID convention:** IDs cross-reference findings in the audit notes under `docs/agent-os/runs/`. Prefix meanings: `BUG` = confirmed bug · `MIS` = doc/package misalignment · `WEAK` = API weakness · `F` = feature · `S` = SEO content · `N` = finding new in 2026-05-24 refresh.
+
+Source audits:
+- `docs/agent-os/runs/2026-04-12-full-repo-audit-investigation.md` (BUG/MIS/WEAK/F/S items)
+- Inline refresh on 2026-05-24 (N items)
+
+---
+
+## Pending
+
+### Wave 1 — Truth fixes (doc accuracy, low risk)
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| ~~BUG-3~~ | ~~docs~~ | ~~high~~ | ~~Audit and correct CHANGELOG — `[Cacheable]` / `FromModel` / `FromRouteOrQuery` entries~~ | **Complete** — see entry in Complete table below. |
+| BUG-4 | docs | high | Remove dead link to `docs/performance-and-observability.md` (or create the file) | Linked from both READMEs at line 198. |
+| N-1 | docs | high | Remove or create `Sample/Sample.http` reference | Referenced in both READMEs at line 166; file does not exist. |
+| MIS-1 | docs | high | Reconcile `net6.0` claim with `.csproj` `net8.0`-only | Either restore multi-targeting or update both READMEs (line 30). See also N-8 (framework currency). |
+| MIS-2 | docs | medium | Fix `GetAsync` XML remarks ("return false" → "returns null") | `src/.../Interfaces/IRedisCacheManager.cs:28`. |
+| MIS-3 | docs | high | Fix decorator example — current `LoggingCacheManager<T>` registration creates circular DI | Both READMEs line 128. Either rewrite with Scrutor `Decorate()` pattern or remove. |
+
+### Wave 2 — Correctness
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| BUG-1 | bug | high | Fix `RemoveAsync_ShouldThrowArgumentException_WhenKeyIsEmpty` calling wrong method | Test at `test/.../RedisCacheManagerTests.cs:538` calls `RefreshAsync` instead of `RemoveAsync`. |
+| BUG-2 | bug | high | `Set(key, entity, options)` should throw `ArgumentNullException` for null key | `src/.../Services/RedisCacheManager.cs:74` throws `ArgumentException` for both null and whitespace; contract requires `ArgumentNullException` for null. Replace manual guard with `Guard.Against.NullOrWhiteSpace`. |
+| N-2 | bug | medium | Fix CS8618 warning in `Sample/Book.cs:6` | `string Name` lacks initializer; add `= string.Empty;` or mark `required` / nullable. |
+| N-3 | bug | medium | Fix CS8604 in `Sample/Program.cs:9` (null connection string) | `GetConnectionString("Redis")` is `string?` passed to `AddRedisCacheManager(string)`. Either guard in the sample or make the public API accept `string?` and throw with a clear message. Affects copy-pasted user code. |
+| BUG-1-test | test | medium | Add missing `RemoveAsync("")` test | Pair with BUG-1 fix; verify the guard is exercised. |
+| N-7 | test | low | Add `GetAsync_ShouldReturnNull_WhenPayloadCannotBeDeserialized` | Async parallel of existing `TryGet` corrupt-payload test. |
+| N-6 | test | low | Rename two tests that say "Refresh" but test Remove | `Remove_ShouldCallDistributedCacheRefresh_WhenCalled` (line 420) and `RemoveAsync_ShouldCallDistributedCacheRefresh_WhenCalled` (line 498). |
+
+### Wave 3 — Hygiene & repo health
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| N-4 | refactor | high | Fix `.gitignore` — `/docs/` and `CLAUDE.md` are tracked but ignored | Blocks `git add .` for new files in `docs/agent-os/runs/`, new SEO articles in `docs/`, and updates to `CLAUDE.md`. Will silently break W-09 and W-10. Remove those lines or scope them more narrowly. |
+| N-5 | refactor | medium | Gate `<GeneratePackageOnBuild>` to Release configuration | `dotnet build` (Debug) currently produces a `.nupkg` in `bin/`. Add `Condition="'$(Configuration)' == 'Release'"`. |
+| MIS-4 | docs | medium | Differentiate root README vs NuGet README | Files are byte-identical today. NuGet README should drop repo-only links (test/, internal docs). |
+| MIS-5 | docs | medium | Update `.csproj` `<Description>` to a proper NuGet-listing sentence | Current value is lowercase and generic. |
+| MIS-6 | docs | medium | Expand `<PackageTags>` | Add `aspnetcore`, `distributed-cache`, `IDistributedCache`, `stackexchange-redis`, `caching`, `json`, `dotnet`. |
+
+### Wave 4 — Small features (target v2.2.0, non-breaking)
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| F-01 | feature | medium | Add `GetOrSetAsync(key, factory, options?, ct)` | Highest-impact addition: collapses the most common 4-line pattern to one call. |
+| F-02 | feature | medium | Add `TryRemoveAsync` and `TryRefreshAsync` returning `Task<bool>` | Completes Try-API symmetry across sync and async. |
+| F-07 | feature | low | Add `RedisCacheManagerOptions` alias with `[Obsolete]` on misspelled name | Removes WEAK-3 friction without breaking callers. |
+| WEAK-5 | feature | low | Surface deserialization failures (configurable handler or log hook) | Currently `JsonException` is swallowed silently in `Deserialize`. |
+
+### Wave 5 — Larger / breaking (target v3.0.0)
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| F-03 | feature | medium | Restore multi-targeting (`net6.0;net8.0`) | Couples with MIS-1; closes the README mismatch. |
+| N-8 | feature | medium | Investigate adding `net9.0` / `net10.0` to multi-target set | Expands install base for newer projects. |
+| F-04 | feature | low | Add batch operations: `GetManyAsync`, `RemoveManyAsync` | Common when invalidating entity sets. |
+| F-05 | feature | low | OpenTelemetry / DiagnosticSource integration | Emit cache hit/miss spans without requiring a decorator. |
+| F-08 | feature | low | Cache-stampede protection (semaphore on first miss) | Prevents thundering herd on cold-start. |
+| WEAK-4 | feature | low | Async `TryGetAsync` returning `(bool, TEntity?)` or equivalent | Removes sync/async asymmetry in the get path. |
+
+### Wave 6 — Content (rolling, SEO opportunities)
+
+| ID | Type | Priority | Title | Notes |
+|---|---|---|---|---|
+| S-01 | content | low | "Strongly-typed Redis caching in .NET 8 with System.Text.Json" | Keyword: strongly typed redis cache dotnet. |
+| S-02 | content | low | "Testing Redis caching in .NET without a real Redis server" | Keyword: unit test redis cache dotnet. |
+| S-03 | content | low | "IRedisCacheManager vs IDistributedCache" | Honest comparison; both have valid uses. |
+| S-04 | content | low | "Multi-tenant Redis key isolation in .NET using InstanceName" | Keyword: redis key prefix dotnet multi-tenant. |
+| S-05 | content | low | "Cache-aside pattern in ASP.NET Core step by step" | Full walkthrough with CacheManager.Redis. |
+| S-06 | content | low | "Adding logging and metrics to Redis cache in ASP.NET Core" | Decorator pattern (requires MIS-3 fix first). |
+| S-07 | content | low | "Sliding vs absolute expiration in Redis: when to use each in .NET" | `DistributedCacheEntryOptions` deep-dive. |
+
+---
+
+## In Progress
+
+| ID | Type | Title | Started | Artifact |
+|---|---|---|---|---|
+
+## Blocked
+
+| ID | Type | Title | Reason |
+|---|---|---|---|
+
+## Complete
+
+| ID | Type | Title | Version | Artifact |
+|---|---|---|---|---|
+| BUG-3 | docs | Correct CHANGELOG v1.3.0 and v2.1.0 entries (remove fictional `[Cacheable]` claims) | unreleased (on `dev` as of 2026-05-24, commit `dbf1a8c`) | `runs/2026-05-24-bug-3-changelog-cacheable-investigation.md` · `runs/2026-05-24-bug-3-changelog-cacheable-plan.md` · `runs/2026-05-24-bug-3-changelog-cacheable-verification.md` |

--- a/docs/agent-os/README.md
+++ b/docs/agent-os/README.md
@@ -1,0 +1,70 @@
+# Agent OS v1 — CacheManager.Redis
+
+This directory contains the operating specification for working on CacheManager.Redis with Claude as a disciplined coding partner. It defines how work is explored, implemented, and released.
+
+## Start here
+
+Read [`AGENT-OS.md`](AGENT-OS.md). It is the complete spec. Everything else is a supporting file.
+
+## How to start a session
+
+State the mode and task at the top of your prompt:
+
+```
+Mode: Investigate
+Task: GetAsync returns null even when a key exists in Redis
+Context: Reported by user, happens only with nullable reference types
+```
+
+Available modes: `Orchestrate` | `Explore` | `Investigate` | `Build` | `Release` | `Content`
+
+If you do not specify a mode, Claude defaults to **Explore** and will not make changes.
+
+## Directory structure
+
+```
+docs/agent-os/
+├── AGENT-OS.md          ← full spec: modes, workflows, gating rules, release discipline
+├── README.md            ← this file
+├── workflows/           ← detailed procedure for each workflow
+├── templates/           ← artifact templates (fill these in during sessions)
+└── runs/                ← session artifacts: investigation notes, plans, verification notes
+```
+
+## Quick reference: which mode for what
+
+| I want to... | Mode |
+|---|---|
+| Work through my task backlog | Orchestrate |
+| Understand the codebase | Explore |
+| Investigate a bug or idea | Investigate |
+| Write or fix code | Build |
+| Bump version, pack, publish | Release |
+| Write docs, samples, SEO articles | Content |
+
+## Quick reference: required artifacts
+
+| Before... | You need... |
+|---|---|
+| Starting Build | Approved Implementation Plan |
+| Starting Release | Verification Note + complete Release Checklist + on `main` |
+| Publishing to NuGet | GitHub release live + Package Validation Note |
+| Writing an SEO article | Approved SEO Article Brief |
+
+## Important safety rule
+
+Claude must not run external actions such as `git push`, `gh release create`, or `dotnet nuget push` without explicit confirmation for each action.
+
+## Templates
+
+| Template | When |
+|---|---|
+| `exploration-summary.md` | Structured Explore output |
+| `task-entry.md` | Every Investigate, Build, Release, and Content session; optional for Explore |
+| `investigation-note.md` | Every Investigate session |
+| `implementation-plan.md` | Before every Build session |
+| `verification-note.md` | After every Build session |
+| `release-checklist.md` | Every Release session |
+| `changelog-entry.md` | Every release |
+| `seo-article-brief.md` | Before every SEO article |
+If unsure which mode to use, start in **Investigate**.

--- a/docs/agent-os/runs/2026-04-12-full-repo-audit-investigation.md
+++ b/docs/agent-os/runs/2026-04-12-full-repo-audit-investigation.md
@@ -1,0 +1,261 @@
+# Investigation Note — Full Repo Audit
+
+**Date:** 2026-04-12  
+**Mode:** Investigate  
+**Task:** Full repo audit — bugs, weaknesses, doc/package misalignments, feature ideas, SEO content opportunities  
+**Files investigated:** All source, all tests, both READMEs, CHANGELOG.md, Sample/, docs/
+
+---
+
+## What Was Investigated
+
+- `src/CacheManager.Redis/` — all 8 source files
+- `test/CacheManager.Redis.Tests/` — all test files and both `.csproj` files
+- `README.md` (root) and `src/CacheManager.Redis/README.md` (NuGet)
+- `CHANGELOG.md`
+- `Sample/Program.cs` and `Sample/Controllers/MainController.cs`
+- `docs/redis-cache-dotnet-guide.md`
+- `docs/agent-os/BACKLOG.md`
+
+---
+
+## Section 1 — Confirmed Bugs
+
+### BUG-1: Test covers wrong method — `RemoveAsync` empty-key path is untested
+
+**File:** `test/CacheManager.Redis.Tests/Services/RedisCacheManagerTests.cs`, line 530  
+**Test name:** `RemoveAsync_ShouldThrowArgumentException_WhenKeyIsEmpty`
+
+The test body calls `redisCacheManager.RefreshAsync(string.Empty)` — not `RemoveAsync`. So `RemoveAsync("")` is never exercised, meaning the guard on `RemoveAsync` for empty keys has zero test coverage. The actual `RemoveAsync` implementation is correct (uses `Guard.Against.NullOrWhiteSpace`), but the missing test hides any future regression.
+
+```csharp
+// What the test says it tests:
+Func<Task> act = async () => await redisCacheManager.RemoveAsync(null);
+
+// What the empty-key test actually calls (line 538):
+Func<Task> act = async () => await redisCacheManager.RefreshAsync(string.Empty); // BUG
+```
+
+---
+
+### BUG-2: `Set(key, entity, DistributedCacheEntryOptions)` throws wrong exception type for null key
+
+**File:** `src/CacheManager.Redis/Services/RedisCacheManager.cs`, line 73–76
+
+All throwing overloads that receive a null key must throw `ArgumentNullException` per the interface XML docs. The `Set(key, entity, options)` overload uses `!key.HasValue()` + manual `throw new ArgumentException(...)`, which throws `ArgumentException` for *both* null and whitespace — violating the contract.
+
+| Overload | Null key behaviour | Correct? |
+|---|---|---|
+| `Set(key, entity)` | `Guard.Against.NullOrWhiteSpace` → `ArgumentNullException` | ✅ |
+| `Set(key, entity, options)` | `!key.HasValue()` → `ArgumentException` | ❌ |
+| `SetAsync(key, entity, ct)` | `Guard.Against.NullOrWhiteSpace` → `ArgumentNullException` | ✅ |
+| `SetAsync(key, entity, opts, ct)` | `Guard.Against.NullOrWhiteSpace` → `ArgumentNullException` | ✅ |
+
+No test exists for `Set(null, entity, options)`, so this is currently silent. The fix is to replace the manual guard in that overload with `Guard.Against.NullOrWhiteSpace(key)`.
+
+---
+
+### BUG-3: `[Cacheable]` attribute and related types are claimed in CHANGELOG but do not exist in source
+
+**CHANGELOG entries:**
+- v1.3.0: "Added `[Cacheable]` action filter with static key support, `FromRouteOrQuery`, `FromModel`"
+- v2.1.0: "Added: Cache key prefix support on `[Cacheable]` attribute"
+
+**Reality:** Zero matches for `Cacheable`, `FromModel`, or `FromRouteOrQuery` in `src/` or `test/`. These types were either never merged into the branch being shipped, or were removed without a CHANGELOG `Removed` entry.
+
+**Risk:** Users reading the CHANGELOG expect a `[Cacheable]` attribute to exist. It does not. This is a truthfulness and trust issue for anyone evaluating the package.
+
+---
+
+### BUG-4: Dead link — `docs/performance-and-observability.md` referenced in both READMEs but does not exist
+
+**Files:** `README.md:198`, `src/CacheManager.Redis/README.md:198`
+
+```markdown
+See [`docs/performance-and-observability.md`](docs/performance-and-observability.md) for additional guidance.
+```
+
+The file `docs/performance-and-observability.md` does not exist in the repository. The link is broken in the root README and in the NuGet package README.
+
+---
+
+## Section 2 — Doc / Package Misalignments
+
+### MIS-1: README claims `net6.0` support; `.csproj` only targets `net8.0`
+
+**Files:** `README.md:30`, `src/CacheManager.Redis/README.md:30`, `CacheManager.Redis.csproj:10`
+
+Both READMEs say: "Target frameworks: `net6.0`, `net8.0`."  
+The `.csproj` has `<TargetFramework>net8.0</TargetFramework>` (singular — not multi-target).  
+The test project also targets `net8.0` only.  
+A `net8.0`-only package cannot be installed into a `net6.0` project via NuGet. Users on net6 will get an error. The CHANGELOG v2.0.0 says "net6.0 support retained" but the project file contradicts this.
+
+Options: either restore multi-targeting (`<TargetFrameworks>net6.0;net8.0</TargetFrameworks>`) or update docs to say "net8.0 only."
+
+---
+
+### MIS-2: `GetAsync` XML doc remarks copied verbatim from `TryGet` — type mismatch
+
+**File:** `src/CacheManager.Redis/Interfaces/IRedisCacheManager.cs`, line 28–30
+
+```xml
+/// <remarks>
+/// return false if the key is null or whitespace
+/// </remarks>
+```
+
+`GetAsync` returns `Task<TEntity?>`, not `bool`. "return false" is wrong; should say "returns null."
+
+---
+
+### MIS-3: Decorator example in both READMEs causes circular DI dependency
+
+**Files:** `README.md:128–152`, `src/CacheManager.Redis/README.md:128–152`
+
+The example shows `LoggingCacheManager<T>` taking `IRedisCacheManager<T>` as a constructor dependency, then being registered via `options.CustomImplementation = typeof(LoggingCacheManager<>)`. This replaces the `IRedisCacheManager<>` registration with `LoggingCacheManager<>`. When the container tries to resolve `LoggingCacheManager<T>`, it needs `IRedisCacheManager<T>`, which resolves to `LoggingCacheManager<T>` again — circular dependency exception at runtime.
+
+The correct decorator pattern requires registering the inner implementation separately (e.g. using Scrutor's `services.Decorate()` or manually registering `RedisCacheManager<>` under a different key). The current example compiles but fails at runtime. This needs either a corrected code example or removal.
+
+---
+
+### MIS-4: Root README and NuGet README are 100% identical
+
+**Files:** `README.md`, `src/CacheManager.Redis/README.md`
+
+The AGENT-OS spec treats them as distinct. Both files are byte-for-byte identical today. This is a maintenance liability — any update requires touching two files. More importantly, the NuGet README should be optimised for the NuGet discovery context (less repo-context content, no links to `test/` folder).
+
+---
+
+### MIS-5: `.csproj` `<Description>` is lowercase and generic
+
+**File:** `src/CacheManager.Redis/CacheManager.Redis.csproj:8`
+
+```xml
+<Description>a generic redis cache manager for .net applications</Description>
+```
+
+All-lowercase, starts with lowercase "a", uses ".net" instead of ".NET". On NuGet this appears verbatim in the package listing and search results. A more useful description that leads with the value proposition would help discoverability.
+
+---
+
+### MIS-6: `<PackageTags>` are too sparse
+
+**File:** `src/CacheManager.Redis/CacheManager.Redis.csproj:16`
+
+```xml
+<PackageTags>redis, cache manager, generic</PackageTags>
+```
+
+Missing high-value NuGet search terms: `aspnetcore`, `caching`, `distributed-cache`, `stackexchange-redis`, `json`, `dotnet`, `IDistributedCache`. NuGet search uses tags; sparse tags reduce discoverability.
+
+---
+
+## Section 3 — API Weaknesses
+
+### WEAK-1: No async Try variants for Remove and Refresh
+
+`TryRemove` and `TryRefresh` exist in the sync API (return `false` for invalid keys, never throw). The async API has only `RemoveAsync` and `RefreshAsync` — both throw on invalid keys. There is no async non-throwing path. Callers who want "remove if key is valid, else do nothing" in async code must catch exceptions or validate the key themselves.
+
+Missing: `TryRemoveAsync` and `TryRefreshAsync` returning `Task<bool>`.
+
+---
+
+### WEAK-2: No `GetOrSetAsync` helper
+
+The most common use of a cache is: get if present, else compute and store. Today that requires 4 lines:
+
+```csharp
+var cached = await _cache.GetAsync(key, ct);
+if (cached is not null) return cached;
+var value = await ComputeAsync();
+await _cache.SetAsync(key, value, ct);
+```
+
+A `GetOrSetAsync(string key, Func<CancellationToken, Task<TEntity>> factory, DistributedCacheEntryOptions? options, CancellationToken ct)` method would reduce this to one line and is the pattern every caller uses. This is the single highest-impact API addition.
+
+---
+
+### WEAK-3: Typo in options class name is a permanent friction source
+
+`RedisCacheMangerOptions` (missing 'a') — acknowledged as "historical spelling" in docs. Every developer who types this misspells it. Without a sealed constructor or alias, there's no IDE correction. A properly-named alias (`RedisCacheManagerOptions`) with an `[Obsolete]` redirect on the old name would let users use the correct spelling while maintaining backwards compatibility until a major version.
+
+---
+
+### WEAK-4: No `CancellationToken` in sync `TryGet`
+
+`TryGet` is sync-only. In an async controller, calling it blocks a thread while Redis responds. There's no async path that returns `(bool, TEntity?)` — callers must either use `TryGet` (sync) or `GetAsync` (async, returns nullable without the bool). The API asymmetry encourages mixing sync and async patterns incorrectly.
+
+---
+
+### WEAK-5: Serialization errors are silently swallowed in `TryGet`
+
+**File:** `src/CacheManager.Redis/Services/RedisCacheManager.cs`, lines 157–165
+
+`Deserialize()` catches `JsonException` and returns `null`. This means a corrupted cache entry silently returns `false`/`null` from `TryGet` — indistinguishable from a cache miss. There's no way for a caller to know whether the key was absent or whether the stored bytes couldn't be parsed. A log event or configurable error handler would give operators visibility.
+
+---
+
+## Section 4 — Feature Ideas for Future Versions
+
+Listed in rough priority order (highest first):
+
+| ID | Feature | Why |
+|---|---|---|
+| F-01 | `GetOrSetAsync(key, factory, options, ct)` | Eliminates the most common boilerplate; 1-liner cache-aside |
+| F-02 | `TryRemoveAsync` / `TryRefreshAsync` | Completes the Try-API symmetry across sync and async |
+| F-03 | Restored `net6.0` multi-targeting | Matches current README claim; expands install base |
+| F-04 | Batch operations: `GetManyAsync`, `RemoveManyAsync` | Common when invalidating entity sets |
+| F-05 | OpenTelemetry / DiagnosticSource integration | Emit cache hit/miss spans without requiring a decorator |
+| F-06 | Configurable error handler on deserialisation failure | Currently swallowed silently; hook for logging/metrics |
+| F-07 | `RedisCacheManagerOptions` alias (correct spelling) with `[Obsolete]` on old name | Remove friction without breaking callers |
+| F-08 | Cache stampede protection (e.g. `SemaphoreSlim` on first miss) | Prevents thundering herd on cold-start |
+
+---
+
+## Section 5 — SEO Content Opportunities (Current Features Only)
+
+All ideas below are grounded in features that exist today. No invented functionality.
+
+| ID | Article / Guide Idea | Primary Keyword | Angle |
+|---|---|---|---|
+| S-01 | "Strongly-typed Redis caching in .NET 8 with System.Text.Json" | strongly typed redis cache dotnet | Replaces byte[] with IRedisCacheManager<T>; shows serializer config |
+| S-02 | "Testing Redis caching in .NET without a real Redis server" | unit test redis cache dotnet | FakeCustomCacheManager / CustomImplementation swap pattern |
+| S-03 | "IRedisCacheManager vs IDistributedCache — which to use in ASP.NET Core" | IDistributedCache vs redis dotnet | Honest trade-off comparison; both have valid uses |
+| S-04 | "Multi-tenant Redis key isolation in .NET using InstanceName" | redis key prefix dotnet multi-tenant | InstanceName option, collision prevention, environment separation |
+| S-05 | "Cache-aside pattern in ASP.NET Core step by step" | cache-aside pattern aspnetcore | Full walkthrough with CacheManager.Redis; sliding + absolute TTL |
+| S-06 | "Adding logging and metrics to Redis cache in ASP.NET Core" | redis cache logging metrics aspnetcore | Decorator pattern (with corrected DI example) |
+| S-07 | "Sliding vs absolute expiration in Redis: when to use each in .NET" | redis cache expiration dotnet | DistributedCacheEntryOptions deep-dive, practical examples |
+
+The existing `docs/redis-cache-dotnet-guide.md` covers broad Redis/.NET ground. The S-xx articles above each cover a narrower, higher-intent keyword with a concrete how-to that links back to the package.
+
+---
+
+## Risk Surface
+
+- **BUG-3** (`[Cacheable]` in CHANGELOG but absent in code) is the highest trust risk. Users evaluating the package via CHANGELOG believe they're getting an attribute-based caching feature.
+- **BUG-1** (wrong method in test) is a regression risk for `RemoveAsync` empty-key guard.
+- **BUG-2** (wrong exception type) is a silent contract violation; discoverable by consumers who `catch (ArgumentNullException)`.
+- **MIS-1** (net6 claim) will cause install failures for net6 users and support questions.
+- **MIS-3** (broken decorator example) will cause runtime failures for users who follow the README.
+
+---
+
+## Summary: Tickets to Create
+
+| Priority | Category | Short title |
+|---|---|---|
+| High | bug | Fix wrong method call in `RemoveAsync_ShouldThrowArgumentException_WhenKeyIsEmpty` test |
+| High | bug | Fix `Set(key, entity, options)` to throw `ArgumentNullException` for null key |
+| High | bug | Audit and correct CHANGELOG — `[Cacheable]` / `FromModel` / `FromRouteOrQuery` entries |
+| High | docs | Remove dead link to `docs/performance-and-observability.md` (or create the file) |
+| High | docs | Fix decorator example in both READMEs — circular DI or replace with correct pattern |
+| High | docs | Correct net6.0 claim — either restore multi-targeting or update docs |
+| Medium | docs | Fix `GetAsync` XML remarks (says "return false", should say "returns null") |
+| Medium | docs | Update `.csproj` Description and PackageTags |
+| Medium | test | Add missing `RemoveAsync("")` test |
+| Medium | feature | Add `GetOrSetAsync` to interface and implementation |
+| Medium | feature | Add `TryRemoveAsync` / `TryRefreshAsync` |
+| Low | feature | Add `RedisCacheManagerOptions` alias with `[Obsolete]` on misspelled name |
+| Low | content | Write S-01: "Strongly-typed Redis caching in .NET 8 with System.Text.Json" |
+| Low | content | Write S-02: "Testing Redis caching in .NET without a real Redis server" |
+| Low | content | Write S-03: IRedisCacheManager vs IDistributedCache comparison |

--- a/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md
+++ b/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md
@@ -1,0 +1,130 @@
+# Investigation Note: BUG-3 — CHANGELOG describes `[Cacheable]` feature that never shipped
+
+Date: 2026-05-24
+Task: BUG-3 (from `docs/agent-os/BACKLOG.md`) — Audit and correct CHANGELOG entries for `[Cacheable]` / `FromModel` / `FromRouteOrQuery`
+Mode at time of writing: Investigate
+
+## What Was Investigated
+
+- `CHANGELOG.md` — current v1.3.0 and v2.1.0 entries
+- `git log --all -S "Cacheable" / "FromModel" / "FromRouteOrQuery"` — locate every commit referencing the type names
+- `git branch -a` — enumerate all local and remote branches
+- `git ls-tree -r v1.3.0`, `v2.1.0`, `v2.1.1` — verify file presence at each release tag
+- `git diff v1.2.0..v1.3.0 --name-status` — confirm what files actually shipped in v1.3.0
+- `git diff v2.0.0..v2.1.0 --stat` — confirm what files actually shipped in v2.1.0
+- `git diff v1.2.0..v1.3.0 -- src/.../IRedisCacheManager.cs` — list real API additions in v1.3.0
+- `git diff v1.2.0..v1.3.0 -- test/.../RedisCacheManagerTests.cs` — list real test additions in v1.3.0
+- `git diff main..12-cache-manager-attribute --name-only` — list files unique to the unreleased feature branch
+
+## Findings
+
+### Root cause
+
+The `[Cacheable]` action filter, `FromModel`, and `FromRouteOrQuery` features exist only on the branch `12-cache-manager-attribute` (present locally and at `origin/12-cache-manager-attribute`). The branch was never merged into `main` or `dev`. The CHANGELOG entries for v1.3.0 and v2.1.0 describe this branch's work as if it had shipped — it has not.
+
+### Evidence
+
+**1. All four `Cacheable`-related commits live on a single branch that's unmerged:**
+
+```
+d666c55  Cacheable Action Filter Implemented with static key
+bbac702  Cacheable key type implemented now the key can be provided from query, route or a binded model
+a5d77f9  cleaning
+b2400aa  Prefix option added for attribute, system provides default prefix for FromModel and FromRouteOrQuery
+```
+
+`git branch --contains 12-cache-manager-attribute` reports only `12-cache-manager-attribute` itself. Last commit on the branch: `a5d77f9` (2024-11-20). The branch has been dormant for ~18 months.
+
+**2. The branch contains real source files that do not exist anywhere on `main`:**
+
+```
+src/CacheManager.Redis/attributes/CacheableAttribute.cs
+src/CacheManager.Redis/Enums/CacheableKeyType.cs
+```
+
+(Output of `git diff main..12-cache-manager-attribute --name-only` shows additional files unique to that branch — see investigation log.)
+
+**3. No release tag contains any Cacheable-related source:**
+
+`git ls-tree -r v1.3.0 | grep -iE "cacheable|attribute"` returns no results. Same for v2.1.0 and v2.1.1. The tagged file set across all three releases has no Cacheable-related code.
+
+**4. The actual content of v1.3.0 (`git diff v1.2.0..v1.3.0`) is entirely different from what the CHANGELOG claims:**
+
+Files changed:
+```
+A   .gitignore
+M   src/CacheManager.Redis/CacheManager.Redis.csproj
+A   src/CacheManager.Redis/Extensions/Helpers.cs
+M   src/CacheManager.Redis/Interfaces/IRedisCacheManager.cs
+M   src/CacheManager.Redis/Services/RedisCacheManager.cs
+M   test/CacheManager.Redis.Tests/Fakers/FakeCustomCacheManager.cs
+M   test/CacheManager.Redis.Tests/Services/RedisCacheManagerTests.cs
+```
+
+API additions in v1.3.0 (from the interface diff):
+```
+bool TrySet(string key, TEntity entity);
+bool TrySet(string key, TEntity entity, DistributedCacheEntryOptions options);
+bool TryRefresh(string key);
+bool TryRemove(string key);
+```
+
+Test additions in v1.3.0 (selected, ~20+ new tests):
+- `TrySet_*`, `TryRefresh_*`, `TryRemove_*` happy and null-key paths
+- `Set_/SetAsync_/Refresh_/RefreshAsync_/Remove_/RemoveAsync_` consistent `ArgumentNullException` / `ArgumentException` coverage via Ardalis guards
+
+So **v1.3.0 actually shipped Try-API completion and guard-clause adoption**, not anything attribute-related.
+
+**5. The actual content of v2.1.0 (`git diff v2.0.0..v2.1.0`) is also unrelated to `[Cacheable]`:**
+
+Major changes:
+- `README.md` — 299-line rewrite
+- `Sample/Controllers/MainController.cs` — controller updates
+- `Sample/Sample.http` — removed
+- `src/CacheManager.Redis/Extensions/Setup.cs` — +46 lines (DI registration + scope fix)
+- `src/CacheManager.Redis/Extensions/TypeExtensions.cs` — +5 lines (BaseType null safety)
+- `src/CacheManager.Redis/Services/RedisCacheManager.cs` — +138 lines (sealed class, primary constructor, binary serialization refactor)
+- New `test/.../Extensions/HelpersTests.cs`
+- Expanded `SetupTests`
+
+No Cacheable-related additions whatsoever. The "prefix support" claim is fictional with respect to what shipped.
+
+### What is wrong, line by line
+
+**CHANGELOG.md v1.3.0 — `Added` section:**
+```
+- `[Cacheable]` action filter with static key support.
+- Cache key derivation from request route and query parameters via `FromRouteOrQuery`.
+- Cache key derivation from a bound model via `FromModel`.
+```
+None of these shipped in v1.3.0. They describe `12-cache-manager-attribute` branch work.
+
+**CHANGELOG.md v2.1.0 — `Added` section:**
+```
+- Cache key prefix support on `[Cacheable]` attribute. The system provides default prefixes for `FromModel` and `FromRouteOrQuery`.
+```
+The `[Cacheable]` attribute does not exist in the v2.1.0 release artifact, so prefix support on it cannot exist either.
+
+## Reproduction Steps
+
+1. Install `CacheManager.Redis` 2.1.1 from NuGet (or check out tag `v2.1.1` locally).
+2. Search the installed assembly / package contents for any type named `CacheableAttribute`, `Cacheable`, `FromModel`, or `FromRouteOrQuery`.
+3. **Expected** (per CHANGELOG v1.3.0 and v2.1.0): types exist; `[Cacheable]` attribute is usable in controllers.
+4. **Actual**: types do not exist; `using CacheManager.Redis.attributes;` fails to resolve; user reading the CHANGELOG concludes a feature is missing or broken.
+
+## Risk Surface
+
+This is a documentation/trust issue. No source files need to change.
+
+- **Public API surface:** unaffected (the feature does not exist; correcting the CHANGELOG cannot change what already shipped).
+- **Serialization behavior:** unaffected.
+- **Registration / DI lifetime:** unaffected.
+- **Existing tests:** unaffected.
+- **External consumers:** anyone who chose this package on NuGet because of the CHANGELOG mentions of `[Cacheable]` was misled. Correcting the entries makes future evaluators see an honest picture. There is no risk of breaking a real caller because the type they think they're using does not exist.
+- **Branch hygiene:** `12-cache-manager-attribute` remains as a candidate for future implementation. Out of scope for this fix, but worth tracking — recommend a follow-up backlog item to either resurrect, archive, or delete that branch.
+
+## Recommendation
+
+**Fix.** Replace both incorrect CHANGELOG entries with accurate descriptions of what actually shipped in those versions, derived from the `git diff` evidence above. No source-code changes needed. An Implementation Plan follows: `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md`.
+
+Also worth a separate backlog entry (not in this fix): decide what to do with the dormant `12-cache-manager-attribute` branch — either ship it in a future minor version, archive it as a documented design exploration, or delete it.

--- a/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md
+++ b/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: BUG-3 — Correct CHANGELOG entries for v1.3.0 and v2.1.0
+
+Date: 2026-05-24
+Investigation Note: `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md`
+Approved by: pending
+
+## Problem
+
+`CHANGELOG.md` v1.3.0 and v2.1.0 describe a `[Cacheable]` action filter and related `FromModel` / `FromRouteOrQuery` features that have never shipped in any released version. The feature lives only on an unmerged branch (`12-cache-manager-attribute`). Anyone reading the CHANGELOG on the repo or NuGet expects functionality that does not exist.
+
+## Solution
+
+Replace the inaccurate entries with descriptions of what each release actually contained, derived from `git diff` evidence captured in the Investigation Note. This is a documentation-only fix. No source files change.
+
+The replacement text is fully specified below. Build mode should copy-paste it verbatim — do not paraphrase, do not add additional improvements, do not reorder unrelated entries.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `CHANGELOG.md` | Replace the v1.3.0 entry (lines 52–63 in current file) with the v1.3.0 replacement block below. Replace the v2.1.0 entry (lines 15–27) with the v2.1.0 replacement block below. No other entries change. No file metadata, headings, or version ordering changes. |
+
+### v1.3.0 — replacement block
+
+Replace the current v1.3.0 entry with:
+
+```markdown
+## [1.3.0] — 2024-05-11
+
+### Added
+- `TrySet(key, entity)` and `TrySet(key, entity, options)` — non-throwing write variants returning `bool`.
+- `TryRefresh(key)` — non-throwing refresh variant returning `bool`.
+- `TryRemove(key)` — non-throwing remove variant returning `bool`.
+- `Helpers.HasValue` string extension method.
+
+### Changed
+- `Set` / `SetAsync` / `Refresh` / `RefreshAsync` / `Remove` / `RemoveAsync` now consistently throw `ArgumentNullException` for null keys and `ArgumentException` for empty/whitespace keys, via `Ardalis.GuardClauses`.
+
+### Internal
+- Expanded null-key and guard-clause test coverage across the API surface.
+- Added repository `.gitignore`.
+```
+
+### v2.1.0 — replacement block
+
+Replace the current v2.1.0 entry with:
+
+```markdown
+## [2.1.0] — 2026-02-13
+
+### Changed
+- Refactored `RedisCacheManager<T>` to a `sealed` class using a primary constructor.
+- Switched serialization to `JsonSerializer.SerializeToUtf8Bytes` / `JsonSerializer.Deserialize<T>(byte[])`, avoiding intermediate string allocations.
+- Hardened `TypeExtensions.IsAssignableToGenericType` against null `BaseType` traversal.
+- Adjusted `AddRedisCacheManager` registration so `IRedisCacheManager<T>` is registered as scoped and the underlying `IRedisDistributedCache` as singleton (carrying serializer/options metadata).
+
+### Internal
+- Major README rewrite covering installation, registration, API usage, decorators, sample, and testing.
+- Expanded unit-test coverage across `RedisCacheManager`, `Setup`, and `Helpers` (new `HelpersTests.cs`).
+- Sample project cleanup: controller updates, `Sample.http` removed, `appsettings.Development.json` simplified.
+```
+
+Note for Build mode: there is intentionally no `### Added` section for v2.1.0. Inspection of `git diff v2.0.0..v2.1.0` shows no new public API surface was added in that release — every visible change is refactoring or internal/test work. Do not invent an Added section.
+
+## New Files
+
+None.
+
+## Public API Changes
+
+None. This is a documentation-only change to `CHANGELOG.md`. No interfaces, classes, methods, or DI registrations are touched.
+
+Breaking: No.
+
+## Test Plan
+
+- [ ] Run `dotnet test` after the edit to confirm the build is unaffected. (Tests should all pass exactly as before — there is no code under change.)
+- [ ] Manual diff review: confirm the only file modified is `CHANGELOG.md`, and within it only the v1.3.0 and v2.1.0 entry blocks change.
+
+## Out of Scope
+
+These items belong to other backlog entries and **must not be touched during this Build session**:
+
+- Not deleting, archiving, or merging the `12-cache-manager-attribute` branch. (Recommend a separate backlog entry to decide its fate.)
+- Not implementing `[Cacheable]`, `FromModel`, or `FromRouteOrQuery` in source.
+- Not adding a `### Removed` section anywhere — these features were never released, so they cannot be "removed" from a CHANGELOG.
+- Not touching `README.md` or `src/CacheManager.Redis/README.md` (those have their own dead-link and doc-accuracy backlog items: BUG-4, N-1, MIS-1, MIS-2, MIS-3).
+- Not bumping the package version. Per AGENT-OS, CHANGELOG corrections that don't reflect a new release are not themselves a release; the next genuine release (e.g. v2.1.2 or v2.2.0) can incorporate this corrected history under its own version bump in Release mode.
+- Not modifying any other CHANGELOG entry (v1.0.0, v1.1.0, v1.2.0, v1.4.0, v2.0.0, v2.1.1) — the investigation only confirmed inaccuracy in v1.3.0 and v2.1.0.

--- a/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-verification.md
+++ b/docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-verification.md
@@ -1,0 +1,68 @@
+# Verification Note: BUG-3 — CHANGELOG corrections for v1.3.0 and v2.1.0
+
+Date: 2026-05-24
+Implementation Plan: `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md`
+Investigation Note: `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md`
+Mode at time of writing: Build
+
+## Summary of Changes Made
+
+Single file modified: `CHANGELOG.md`. Two block replacements applied verbatim from the approved Implementation Plan:
+
+1. **v1.3.0 entry (lines 53–63)** — replaced inaccurate `Added` section claiming `[Cacheable]` / `FromRouteOrQuery` / `FromModel` with the real shipped content: `TrySet` / `TryRefresh` / `TryRemove` non-throwing variants, `Helpers.HasValue`, guard-clause adoption across throwing overloads, and expanded test coverage.
+2. **v2.1.0 entry (lines 15–25)** — removed the inaccurate `Added` section claiming `[Cacheable]` prefix support. The replacement `Changed` section describes the real shipped content: `RedisCacheManager<T>` refactor (sealed + primary constructor), binary serialization switch, `TypeExtensions` null safety, and DI lifetime adjustments. The `Internal` section expanded to cover the actual README rewrite, new `HelpersTests.cs`, and sample cleanup.
+
+No other entries (v1.0.0, v1.1.0, v1.2.0, v1.4.0, v2.0.0, v2.1.1) were touched. No source files, tests, or documentation were touched.
+
+## Test Results
+
+```
+dotnet build CacheManager.Redis.sln
+→ Build succeeded. 0 Warning(s), 0 Error(s).
+
+dotnet test CacheManager.Redis.sln
+→ Passed!  Failed: 0, Passed: 51, Skipped: 0, Total: 51
+```
+
+Pre-existing warnings (`CS8618` in `Sample/Book.cs`, `CS8604` in `Sample/Program.cs`) did not surface in this build because the assemblies were up-to-date from the earlier Explore-mode build in this session and were not recompiled. They are unrelated to BUG-3 and remain in the backlog as N-2 and N-3.
+
+## Deviations from the Plan
+
+None on the substance. Two minor process notes:
+
+1. **Mode-boundary nuance.** The Implementation Plan listed `CHANGELOG.md` as the file to change in Build mode, but AGENT-OS spec assigns `CHANGELOG.md` editing primarily to Release mode. I proceeded in Build mode because this is a historical-truthfulness fix, not release preparation — analogous to the README accuracy edits Build explicitly allows. Flagged for your awareness; not a violation if treated as a doc-correctness exception.
+2. **Old-string text drift.** First Edit attempt failed because my Investigation Note had paraphrased the v2.1.0 `Added` bullet slightly (dropped " key sources." from the end). Re-read the file and the second attempt matched exactly. The replacement text written into the file is from the Plan and is unchanged.
+
+## Known Gaps & Follow-up Items
+
+The following items surfaced during this session but are **out of scope** for BUG-3 and remain on the backlog:
+
+1. **`CHANGELOG.md` is currently untracked in git.** Confirmed via `git log --all --follow -- CHANGELOG.md` (returns no commits) and `git status` (file shows as `??`, not `M`). It is not gitignored — just never `git add`-ed. This is a pre-existing condition that predates this session. When committing this fix, use `git add CHANGELOG.md` explicitly (it won't be picked up by `git status` review the same way modified files are).
+2. **Pre-existing dirty working tree.** At session start the following were already modified or untracked, and I did not change any of them: `M .gitignore`, `M README.md`, `M src/CacheManager.Redis/CacheManager.Redis.csproj`, `M src/CacheManager.Redis/README.md`, `?? .DS_Store`, `?? test/.DS_Store`. Worth a separate Orchestrate-mode pass before any release work — they may be in-progress unrelated edits or stale state. **Do not bundle them into the BUG-3 commit** unless you intend to.
+3. **N-4 confirmed in practice.** The BACKLOG.md update from earlier in this session, and both Investigate/Build/Verification artifacts written today under `docs/agent-os/runs/`, are on disk but invisible to `git status` because `.gitignore` contains `/docs/`. To commit any of them you must use explicit paths: `git add docs/agent-os/BACKLOG.md docs/agent-os/runs/2026-05-24-*.md`. This is why N-4 is high-priority — it silently breaks every Investigate/Build/Content session output flow.
+4. **`12-cache-manager-attribute` branch fate.** Investigation Note recommended a separate backlog entry to decide whether to ship, archive, or delete the dormant feature branch. Not added — that's an Orchestrate-mode action.
+
+## Files Changed (final list)
+
+| File | Status | Note |
+|---|---|---|
+| `CHANGELOG.md` | modified on disk; still untracked in git | Two block replacements per plan |
+| `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md` | new on disk; gitignored by `/docs/` rule | Investigation Note |
+| `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md` | new on disk; gitignored by `/docs/` rule | Implementation Plan |
+| `docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-verification.md` | new on disk; gitignored by `/docs/` rule | This file |
+| `docs/agent-os/BACKLOG.md` | modified on disk; gitignored by `/docs/` rule | Earlier in this session (Orchestrate mode) |
+
+## Handoff
+
+Per AGENT-OS, Build mode stops here. The change is verified and ready for your review. To commit:
+
+```bash
+git add CHANGELOG.md
+git add docs/agent-os/BACKLOG.md \
+        docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-investigation.md \
+        docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-plan.md \
+        docs/agent-os/runs/2026-05-24-bug-3-changelog-cacheable-verification.md
+git commit -m "docs(changelog): correct v1.3.0 and v2.1.0 entries (BUG-3)"
+```
+
+(Per Hard Rules I will not run these without explicit instruction. The pre-existing modified files listed above are intentionally excluded.)

--- a/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-investigation.md
+++ b/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-investigation.md
@@ -1,0 +1,99 @@
+# Investigation Note: N-4 — `.gitignore` silently excludes the entire Agent OS spec and `CLAUDE.md`
+
+Date: 2026-05-24
+Task: N-4 (from `docs/agent-os/BACKLOG.md`, Wave 3) — `.gitignore` ignores `/docs/` and `CLAUDE.md` but both directories' content is intended to be tracked
+Mode at time of writing: Investigate
+
+## What Was Investigated
+
+- `.gitignore` — current content and full history (`git log --oneline -- .gitignore`)
+- `git show 08d23477` — original `.gitignore` introduced 2024-05-11
+- `git show dbf1a8c` — most recent `.gitignore` change (the bundled BUG-3 commit, today)
+- `git ls-files docs/` — what's actually tracked under `docs/`
+- `git ls-files CLAUDE.md` — whether the project bootstrap file is tracked
+- `find docs -type f` — what exists on disk under `docs/`
+- `docs/agent-os/AGENT-OS.md` § "Suggested Repository Structure" and § "Recommended First Iteration Plan" — declared intent for `docs/agent-os/` tracking
+
+## Findings
+
+### Root cause
+
+The lines `/docs/` and `CLAUDE.md` were added to `.gitignore` in today's bundled commit `dbf1a8c` ("change log added, readme updated."). They were **not** present in the original `.gitignore` introduced by commit `08d23477` (2024-05-11). The original file contained only build-output and IDE-state exclusions:
+
+```
+/Sample/obj/        /Sample/bin/
+/.idea/             /CacheManager.Redis.sln.DotSettings.user
+/src/CacheManager.Redis/bin/    /src/CacheManager.Redis/obj/
+/test/CacheManager.Redis.Tests/bin/    /test/CacheManager.Redis.Tests/obj/
+```
+
+The bundled commit added three lines:
+```
++/artifacts/
++/docs/
++CLAUDE.md
+```
+
+`/artifacts/` is correct — that's the Release-mode pack output directory and should be excluded. The other two are wrong.
+
+### Why this is wrong
+
+`AGENT-OS.md` is explicit that `docs/agent-os/` is the audit trail and must be committed:
+
+- § "Recommended First Iteration Plan", item 1: "~~Commit this spec.~~ Done — `docs/agent-os/` is committed." — this is now factually incorrect.
+- § "Suggested Repository Structure" lists the whole `docs/agent-os/` tree with the comment "session bootstrap (read automatically by Claude Code)" for CLAUDE.md and `← session artifacts (committed)` for `runs/`.
+- The Orchestrate-mode contract says "Orchestrate mode reads `BACKLOG.md`" — `BACKLOG.md` lives in `docs/agent-os/`, so it must be tracked for any cross-session continuity.
+
+`CLAUDE.md` is the standard Claude Code project-bootstrap file — also intended to be committed so every contributor and every session inherits the same mode rules and gates.
+
+### Scope of the breakage on disk
+
+- `git ls-files docs/` returns **zero** results. Nothing under `docs/` is tracked.
+- `git ls-files CLAUDE.md` returns **zero** results. The bootstrap file is not tracked.
+- `find docs -type f` returns **31** files currently on disk:
+  - `docs/agent-os/AGENT-OS.md`, `README.md`, `BACKLOG.md` (3)
+  - `docs/agent-os/workflows/*.md` (15 workflow files)
+  - `docs/agent-os/templates/*.md` (8 templates)
+  - `docs/agent-os/runs/*.md` (4 artifacts: prior audit + the three I produced for BUG-3 today)
+  - `docs/redis-cache-dotnet-guide.md` (the existing SEO article)
+
+All 31 + `CLAUDE.md` would be lost on a fresh `git clone`. The Agent OS system effectively does not exist in the repository — it only exists in this working copy.
+
+### Why the immediate fallout is masked
+
+`git status` does not list these files because `.gitignore` matches them, so a casual `git status` looks clean. The breakage is invisible until someone clones fresh, or until someone runs `git ls-files` and notices the absence.
+
+This session's own work was also affected: the `BACKLOG.md` update earlier, the BUG-3 Investigation/Plan/Verification artifacts, and the file you are reading right now all sit on disk but are invisible to `git status` and `git add .`.
+
+### What about `/artifacts/`?
+
+Should stay ignored. `/artifacts/` is the directory Release mode writes `.nupkg` to (`dotnet pack ... -o ./artifacts`, per `AGENT-OS.md` § "Step 6: Pack"). Generated build output, no value in committing.
+
+## Reproduction Steps
+
+1. From a clean clone of the repository (any branch through `dev`-as-of-commit-`dbf1a8c`):
+   ```bash
+   git clone <repo> && cd CacheManager.Redis
+   ls docs/        # → only build output or nonexistent
+   ls CLAUDE.md    # → No such file or directory
+   ```
+2. **Expected** (per `AGENT-OS.md`): `docs/agent-os/` tree present, `CLAUDE.md` present, so future Claude sessions can find the spec and the backlog.
+3. **Actual**: neither exists. New contributors and new Claude sessions have no spec, no backlog, no bootstrap — the entire Agent OS scaffolding is invisible outside this one working copy.
+
+## Risk Surface
+
+- **Public API surface:** unaffected.
+- **Serialization / DI / tests:** unaffected.
+- **Build:** unaffected (`.gitignore` doesn't influence compilation).
+- **Loss-of-work risk:** **high**. Anyone running `rm -rf` on the working copy, or cloning fresh and switching machines, loses the entire Agent OS spec + history. No automatic recovery.
+- **Session continuity:** every future Investigate / Build / Content session output also lands in `docs/agent-os/runs/` and will be silently ignored until N-4 is fixed.
+- **Coupling:** fixing N-4 unlocks committing the in-flight BACKLOG update, the BUG-3 artifacts produced earlier today, and this artifact itself. None of those can be committed until the gitignore is corrected (or every commit uses explicit paths and the gitignore continues to silently shadow them — fragile).
+- **No risk of accidentally tracking the wrong thing:** the gitignore still excludes `bin/`, `obj/`, `.idea/`, `.DotSettings.user`, and `/artifacts/`. None of those live under `docs/` or share a name with `CLAUDE.md`.
+
+## Recommendation
+
+**Fix.** Remove the two erroneous lines from `.gitignore`. Keep `/artifacts/`. After the fix, the user runs an explicit `git add` of the recovered files in a single follow-up commit (the actual `git add` is out of scope of the Implementation Plan because it requires user-confirmed staging decisions for ~32 files and is a Hard-Rule-sensitive operation).
+
+An Implementation Plan follows: `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-plan.md`.
+
+Also worth a separate **Orchestrate-mode** follow-up after N-4 lands: a one-off pass to stage and commit all currently-untracked-but-tracked-intent files (the 31 docs files + `CLAUDE.md`) in a coherent commit. Not part of this BACKLOG entry — should be its own line item (e.g., `N-4-recovery`).

--- a/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-plan.md
+++ b/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: N-4 — Stop ignoring `docs/` and `CLAUDE.md`
+
+Date: 2026-05-24
+Investigation Note: `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-investigation.md`
+Approved by: pending
+
+## Problem
+
+`.gitignore` currently excludes `/docs/` and `CLAUDE.md` — both are intended to be tracked per `AGENT-OS.md`. As a result, the entire Agent OS spec, workflows, templates, backlog, run artifacts, the existing SEO article, and the project's CLAUDE.md bootstrap file all sit on disk but have never been committed. A fresh clone loses everything.
+
+## Solution
+
+Remove two lines from `.gitignore`. Keep `/artifacts/` (correct — it's Release-mode pack output). No other change to `.gitignore`. No source/test/sample/README/CHANGELOG changes.
+
+The actual `git add` and `git commit` of the 31 currently-untracked-but-now-trackable files plus `CLAUDE.md` is **out of scope** for this plan — it's a separate human-confirmed staging operation handled in a follow-up task (recommended as `N-4-recovery` in BACKLOG).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `.gitignore` | Remove the lines `/docs/` and `CLAUDE.md`. The file is currently 11 lines (10 entries); after the change it should be 9 lines (8 entries). |
+
+### Exact replacement
+
+The full target content of `.gitignore` after this plan is applied:
+
+```
+/Sample/obj/
+/Sample/bin/
+/.idea/
+/CacheManager.Redis.sln.DotSettings.user
+/src/CacheManager.Redis/bin/
+/src/CacheManager.Redis/obj/
+/test/CacheManager.Redis.Tests/bin/
+/test/CacheManager.Redis.Tests/obj/
+/artifacts/
+```
+
+(No trailing newline change — match the existing convention of the file.)
+
+## New Files
+
+None.
+
+## Public API Changes
+
+None. This is a `.gitignore` change. No code, no interfaces, no public surface, no tests.
+
+Breaking: No.
+
+## Test Plan
+
+- [ ] After the edit, run `git status` — all 31 files under `docs/` and `CLAUDE.md` should now appear as untracked (`??`).
+- [ ] Confirm `/artifacts/` is still ignored: `git check-ignore -v artifacts/anything.nupkg` should still show the rule matching.
+- [ ] Confirm build/test side: `dotnet build` and `dotnet test` are unaffected (no code change), but run them once to be safe.
+- [ ] No new tests are added or modified — this is a repo-config change.
+
+## Out of Scope
+
+- **Not** running `git add docs/` or `git add CLAUDE.md`. That belongs to a separate `N-4-recovery` task with explicit human confirmation per the Hard Rules. The scope of *what* to recover is straightforward (everything currently on disk under `docs/` plus `CLAUDE.md`) but the staging operation is intentionally a human decision point.
+- **Not** committing this `.gitignore` change itself — same reason. Build mode applies the edit; user reviews and commits.
+- **Not** removing `/artifacts/` from `.gitignore` — that rule is correct.
+- **Not** changing any other gitignore rule (`bin/`, `obj/`, `.idea/`, `.DotSettings.user`). All other rules are correct.
+- **Not** touching any other file. No `AGENT-OS.md` updates, no README changes, no CHANGELOG edit, no source-code touch.
+- **Not** rebasing or reordering the bundled commit `dbf1a8c` that introduced the bad lines. History stays as-is; this fix is a forward correction.
+- **Not** deciding whether to commit this on `hygine-repo-health` or after switching to `dev`. That's a branch-strategy decision for the human at apply time.

--- a/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-verification.md
+++ b/docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-verification.md
@@ -1,0 +1,76 @@
+# Verification Note: N-4 — `.gitignore` no longer hides `docs/` and `CLAUDE.md`
+
+Date: 2026-05-24
+Implementation Plan: `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-plan.md`
+Investigation Note: `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-investigation.md`
+Mode at time of writing: Build
+
+## Summary of Changes Made
+
+Single file modified: `.gitignore`. Two lines removed (`/docs/` and `CLAUDE.md`); `/artifacts/` retained. Final file is 9 lines, matching the exact replacement specified in the plan. No other files touched.
+
+## Test Results
+
+### Functional verification (the point of the change)
+
+| Check | Command | Result |
+|---|---|---|
+| `/artifacts/` still ignored | `git check-ignore -v artifacts/CacheManager.Redis.2.1.1.nupkg` | matches rule at `.gitignore:9` |
+| `docs/` no longer ignored | `git check-ignore -v docs/agent-os/AGENT-OS.md` | exit 1 (not ignored) |
+| `CLAUDE.md` no longer ignored | `git check-ignore -v CLAUDE.md` | exit 1 (not ignored) |
+| Recovered files visible to git | `git status --short` | shows `?? CLAUDE.md` and `?? docs/` (covering 31 nested files) |
+
+### Build sanity
+
+```
+dotnet build CacheManager.Redis.sln
+→ Build succeeded. 0 Error(s), 2 Warning(s) — both pre-existing in Sample/
+  - Sample/Book.cs(6,19): CS8618 (tracked as N-2)
+  - Sample/Program.cs(9,39): CS8604 (tracked as N-3)
+
+dotnet test CacheManager.Redis.sln
+→ Passed!  Failed: 0, Passed: 51, Skipped: 0, Total: 51
+```
+
+Confirmed: this change has zero effect on compilation or tests. Both warnings exist independently and are already in the backlog.
+
+## Deviations from the Plan
+
+None. The Edit was a single string replacement on the three trailing lines (`/artifacts/\n/docs/\nCLAUDE.md` → `/artifacts/`), preserving the file's no-trailing-newline convention.
+
+## Known Gaps & Follow-up Items
+
+1. **Recovery commit is needed.** N-4 only fixes the gitignore. The 31 untracked files under `docs/` and `CLAUDE.md` are now *visible* to git but still untracked. They will not enter history until someone runs `git add docs/ CLAUDE.md` and commits. Per the plan, this is explicitly out of scope of N-4 and should be a follow-up task — add `N-4-recovery` to BACKLOG.
+2. **`.DS_Store` files are still untracked and unignored.** `?? .DS_Store` and `?? test/.DS_Store` continue to appear in `git status`. Not in N-4 scope, but worth a one-line fix to `.gitignore` at some point (`.DS_Store` and `**/.DS_Store`). Recommend appending to `N-4-recovery` or its own micro-task.
+3. **Branch state unchanged.** Still on `hygine-repo-health`. Per AGENT-OS, future work should happen on `dev`. Switching is a human decision; not done here.
+
+## Files Changed (final list)
+
+| File | Status | Note |
+|---|---|---|
+| `.gitignore` | modified | 11 lines → 9 lines; removed `/docs/` and `CLAUDE.md` |
+| `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-investigation.md` | new on disk, now visible to git | Investigation Note |
+| `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-plan.md` | new on disk, now visible to git | Implementation Plan |
+| `docs/agent-os/runs/2026-05-24-n-4-gitignore-docs-verification.md` | new on disk, now visible to git | This file |
+| `docs/agent-os/BACKLOG.md` | modified on disk, now visible to git | Earlier in this session (BUG-3 close-out) |
+
+After the recovery commit, all of the above plus 31 other untracked files under `docs/` plus `CLAUDE.md` will enter history for the first time.
+
+## Handoff
+
+Per AGENT-OS, Build mode stops here. The change is verified and ready for review. To land N-4 alone (without the recovery):
+
+```bash
+git add .gitignore
+git commit -m "fix(repo): stop ignoring docs/ and CLAUDE.md (N-4)"
+```
+
+To land N-4 and the recovery together — only do this if you've reviewed what's about to enter history forever:
+
+```bash
+git add .gitignore CLAUDE.md docs/
+git status   # READ this carefully — first commit defines history
+git commit -m "fix(repo): track docs/ and CLAUDE.md from now on (N-4 + recovery)"
+```
+
+(Per Hard Rules I will not run either of these without explicit instruction. Recommend at minimum a quick `git status` + `git diff --cached` review before any commit that touches 32+ new files.)

--- a/docs/agent-os/templates/changelog-entry.md
+++ b/docs/agent-os/templates/changelog-entry.md
@@ -1,0 +1,52 @@
+# Changelog Entry Template
+
+Use this template for each version entry in `CHANGELOG.md` at the repo root.
+
+---
+
+## [X.Y.Z] — YYYY-MM-DD
+
+### Added
+
+- Brief description of new feature or capability. Reference the relevant interface or method if useful.
+
+### Changed
+
+- Brief description of changed behavior. Call out any migration steps if needed.
+
+### Fixed
+
+- Brief description of bug fixed. One line per fix. Optional: reference issue number (`#42`).
+
+### Internal
+
+- Refactors, test additions, tooling updates — changes that do not affect the public API or package consumers.
+
+---
+
+## Rules for writing changelog entries
+
+- Write in the past tense: "Added", "Fixed", "Changed" — not "Add", "Fix", "Change".
+- Entries go at the **top** of `CHANGELOG.md`, above older versions.
+- Do not include internal commit hashes or branch names.
+- Do not include entries for changes that were reverted before release.
+- If a section has no entries, omit it entirely. Do not write "### Fixed\n- None."
+- "Internal" entries are optional. Include them if they help contributors understand what changed.
+
+## Full CHANGELOG.md structure
+
+```markdown
+# Changelog
+
+All notable changes to CacheManager.Redis are documented here.
+
+## [X.Y.Z] — YYYY-MM-DD
+
+### Added
+- ...
+
+## [X.Y.W] — YYYY-MM-DD
+
+### Fixed
+- ...
+```

--- a/docs/agent-os/templates/exploration-summary.md
+++ b/docs/agent-os/templates/exploration-summary.md
@@ -1,0 +1,60 @@
+# Exploration Summary: <scope>
+
+Date: YYYY-MM-DD
+Mode: Explore
+
+---
+
+## Repo Structure
+
+Brief description of the top-level layout and what each directory contains.
+
+```
+src/CacheManager.Redis/     — source
+test/CacheManager.Redis.Tests/ — unit tests
+Sample/                     — ASP.NET Core demo app
+docs/                       — documentation and Agent OS
+```
+
+## Public API Surface
+
+List the public interfaces, their key methods, and a one-line description of each.
+
+### `IRedisCacheManager<TEntity>`
+
+| Method | Description |
+|---|---|
+| `TryGet(key, out TEntity?)` | Synchronous get; returns false if key is null/empty or not found |
+| `GetAsync(key, ct)` | Async get; returns null if not found |
+| `Set(key, entity)` | Synchronous set with default options |
+| `Set(key, entity, options)` | Synchronous set with explicit cache options |
+| `TrySet(key, entity)` | Non-throwing set; returns false if key is null/empty |
+| `SetAsync(key, entity, options, ct)` | Async set |
+| ... | ... |
+
+### `IRedisDistributedCache`
+
+Describe briefly.
+
+### `AddRedisCacheManager` (extension)
+
+Describe the registration signature and what it registers.
+
+## Build State
+
+```bash
+dotnet build  →  <result>
+dotnet test   →  X passed, 0 failed  (run in Investigate mode, not Explore)
+```
+
+## Notable Observations
+
+List anything that stood out during exploration:
+- Gaps in test coverage
+- TODOs or FIXMEs in source
+- Inconsistencies between README and actual API
+- Anything that might warrant an investigation
+
+## Questions / Follow-up
+
+List any questions this exploration raised that were not answered by reading the code.

--- a/docs/agent-os/templates/implementation-plan.md
+++ b/docs/agent-os/templates/implementation-plan.md
@@ -1,0 +1,55 @@
+# Implementation Plan: <title>
+
+Date: YYYY-MM-DD
+Investigation Note: `docs/agent-os/runs/<file>.md`
+Approved by: pending | <name>
+
+## Problem
+
+One sentence. What is broken or missing.
+
+## Solution
+
+Describe the approach concretely. Not "improve the caching layer" — describe what method changes, what interface additions, what behavior shifts.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/CacheManager.Redis/...` | Describe the change |
+| `test/CacheManager.Redis.Tests/...` | Describe the new tests |
+
+## New Files
+
+None.
+
+(Or list them with their purpose.)
+
+## Public API Changes
+
+None. (This plan does not change any public interface.)
+
+(Or describe the exact signature change:)
+```csharp
+// Before
+void Set(string key, TEntity entity);
+
+// After
+void Set(string key, TEntity entity, CancellationToken cancellationToken = default);
+```
+
+Breaking: Yes | No
+
+## Test Plan
+
+- [ ] Test scenario: describe what it verifies
+- [ ] Test scenario: describe what it verifies
+- [ ] Existing tests still pass with no changes
+
+## Out of Scope
+
+Explicit list of things this plan does NOT include. This prevents scope creep during Build.
+
+- Not changing X
+- Not refactoring Y
+- Not updating README (unless explicitly listed in Files to Change)

--- a/docs/agent-os/templates/investigation-note.md
+++ b/docs/agent-os/templates/investigation-note.md
@@ -1,0 +1,41 @@
+# Investigation Note: <title>
+
+Date: YYYY-MM-DD
+Task: <task title>
+Mode at time of writing: Investigate
+
+## What Was Investigated
+
+List the files read, methods traced, and tests run during this session.
+
+- `src/CacheManager.Redis/...` — reason
+- `test/CacheManager.Redis.Tests/...` — reason
+
+## Findings
+
+Describe what was found. Be specific. Reference line numbers or method names where relevant.
+
+If this is a bug: state the root cause.
+If this is a gap: state what is missing and where.
+
+## Reproduction Steps
+
+(Fill in for bugs. Remove this section for enhancement investigations.)
+
+1. Step one
+2. Step two
+3. Expected: X. Actual: Y.
+
+## Risk Surface
+
+What else could be affected by a change in the area investigated. Call out any:
+- Public API surface
+- Serialization behavior
+- Registration / DI lifetime
+- Existing tests that would need updating
+
+## Recommendation
+
+Choose one: Fix | Enhance | Refactor | Defer | No action.
+
+Explain in one paragraph why. If the recommendation is Fix or Enhance, state whether an Implementation Plan should follow.

--- a/docs/agent-os/templates/release-checklist.md
+++ b/docs/agent-os/templates/release-checklist.md
@@ -1,0 +1,72 @@
+# Release Checklist: v<version>
+
+Date: YYYY-MM-DD
+Releasing: CacheManager.Redis v<version>
+Previous version: v<previous>
+Release type: Patch | Minor | Major
+
+---
+
+## Pre-Release: Branch State
+
+- [ ] PR from `dev` to `main` is merged
+- [ ] Currently on `main`: `git branch --show-current` → `main`
+- [ ] `main` HEAD is the merged feature commit, not stale: `git log --oneline -3`
+- [ ] Working tree is clean: `git status` — no unexpected uncommitted files
+- [ ] `./artifacts/` is empty or absent — no stale `.nupkg` from a previous run
+
+## Pre-Release: Code and Tests
+
+- [ ] `dotnet build src/CacheManager.Redis/CacheManager.Redis.csproj` — no errors, no warnings
+- [ ] `dotnet test` — X passed, 0 failed, 0 skipped
+- [ ] Verification Note(s) exist for all changes in this release
+
+## Pre-Release: Version and Metadata
+
+- [ ] `<Version>` in `CacheManager.Redis.csproj` updated to `<version>`
+- [ ] `<Description>` in `.csproj` is accurate
+- [ ] `<PackageTags>` in `.csproj` is accurate
+- [ ] `CLAUDE.md` version updated: `Current version: <version>`
+
+## Pre-Release: Documentation
+
+- [ ] Root `README.md` reflects current API (check all code samples)
+- [ ] `src/CacheManager.Redis/README.md` (NuGet README) reflects current API
+- [ ] `CHANGELOG.md` entry written for `v<version>`
+- [ ] Any new public API is documented in the README
+
+## Pre-Release: Sample
+
+- [ ] `dotnet build Sample/Sample.csproj` — no errors
+
+## Package
+
+- [ ] `dotnet pack -c Release` completed without warnings
+- [ ] Package Validation Note written and saved to `docs/agent-os/runs/`
+- [ ] `.nupkg` filename: `CacheManager.Redis.<version>.nupkg`
+- [ ] `.nupkg` contains `src/CacheManager.Redis/README.md` (the NuGet README — not the root README)
+- [ ] Target frameworks in `.nupkg`: `net6.0`, `net8.0`
+- [ ] Dependencies in `.nupkg`:
+  - [ ] `Ardalis.GuardClauses` 5.x
+  - [ ] `Microsoft.Extensions.Caching.StackExchangeRedis` 8.x
+
+## Release: GitHub
+
+- [ ] Tag `v<version>` created on `main`
+- [ ] Release commit pushed to `origin/main` — **explicit confirmation required**
+- [ ] Tag pushed to origin — **explicit confirmation required**
+- [ ] GitHub release created with changelog as body — **explicit confirmation required**
+- [ ] `.nupkg` attached to GitHub release
+
+## Release: NuGet
+
+- [ ] NuGet publish command ready (API key confirmed available)
+- [ ] `dotnet nuget push` run — **explicit confirmation required**
+- [ ] Package visible on nuget.org (may take up to 15 min)
+- [ ] NuGet README renders correctly
+- [ ] Version badge on GitHub README (if present) reflects new version
+
+## Post-Release
+
+- [ ] Post-release note written in `docs/agent-os/runs/`
+- [ ] Any follow-up tasks logged

--- a/docs/agent-os/templates/seo-article-brief.md
+++ b/docs/agent-os/templates/seo-article-brief.md
@@ -1,0 +1,62 @@
+# SEO Article Brief: <title>
+
+Date: YYYY-MM-DD
+Status: pending approval | approved
+Target package version: v<X.Y.Z>
+
+---
+
+## Target Keyword
+
+Primary: `<keyword>` — e.g., "redis cache dotnet"
+Secondary: `<keyword>`, `<keyword>` — e.g., "strongly typed redis cache", "IDistributedCache"
+
+## Audience
+
+Who is reading this. What they already know. What problem they are trying to solve right now.
+
+Example: "A .NET backend developer integrating Redis into an ASP.NET Core API for the first time. They know C# and DI. They have not used StackExchange.Redis or IDistributedCache before."
+
+## Article Goal
+
+What the reader should be able to do after finishing the article.
+
+Example: "Configure CacheManager.Redis in a new ASP.NET Core project and store/retrieve a typed object from Redis within 15 minutes."
+
+## Factual Constraints
+
+These are hard rules for this article. Do not deviate.
+
+- [ ] All code samples must compile and run against CacheManager.Redis v<X.Y.Z>
+- [ ] Do not claim performance numbers — this package has not published benchmarks
+- [ ] Do not compare to other packages unless the comparison is demonstrably accurate
+- [ ] If any feature is planned but not yet shipped, mark it explicitly: `(planned)`
+- [ ] Do not use the words "enterprise", "battle-tested", or "production-grade" without evidence
+
+## Outline
+
+1. Introduction — hook, primary keyword placement
+2. <section title>
+3. <section title>
+4. <section title>
+5. Conclusion — recap + CTA (e.g., link to NuGet, GitHub)
+
+## Code Samples Required
+
+List each code scenario that needs a working example:
+
+- [ ] Registration in Program.cs
+- [ ] Basic get/set with `IRedisCacheManager<T>`
+- [ ] <additional scenario>
+
+## Word Count Target
+
+~<N> words. Aim for depth over length. Do not pad.
+
+## Output Location
+
+`docs/<filename>.md`
+
+---
+
+**This brief must be approved before article writing begins. Do not start the article without approval.**

--- a/docs/agent-os/templates/task-entry.md
+++ b/docs/agent-os/templates/task-entry.md
@@ -1,0 +1,23 @@
+# Task: <title>
+
+Date: YYYY-MM-DD
+Mode: <Explore | Investigate | Build | Release | Content>
+Status: <open | in-progress | complete | blocked>
+
+## Objective
+
+One sentence. What does done look like.
+
+## Context
+
+Why this task exists. Link to relevant issue, commit, or prior session if applicable.
+
+## Artifacts
+
+- Investigation Note: `docs/agent-os/runs/<file>.md` (if applicable)
+- Implementation Plan: `docs/agent-os/runs/<file>.md` (if applicable)
+- Verification Note: `docs/agent-os/runs/<file>.md` (if applicable)
+
+## Outcome
+
+Filled in when complete. What was produced, what changed, what was deferred.

--- a/docs/agent-os/templates/verification-note.md
+++ b/docs/agent-os/templates/verification-note.md
@@ -1,0 +1,42 @@
+# Verification Note: <title>
+
+Date: YYYY-MM-DD
+Implementation Plan: `docs/agent-os/runs/<file>.md`
+
+## Changes Made
+
+Brief summary of what was changed. Reference files and methods.
+
+| File | What Changed |
+|------|-------------|
+| `src/...` | Description |
+| `test/...` | Description |
+
+## Test Results
+
+```
+dotnet test
+Test Run Summary:
+  Total: X
+  Passed: X
+  Failed: 0
+  Skipped: 0
+```
+
+Paste or summarize the actual output.
+
+## Deviations From Plan
+
+None.
+
+(Or describe any deviations and justify them. If a deviation changes the public API or scope, stop and get approval before proceeding.)
+
+## Follow-Up Items
+
+None.
+
+(Or list anything that was out of scope for this session and should be tracked separately.)
+
+## Release Readiness
+
+Ready for release: Yes | No (reason)

--- a/docs/agent-os/workflows/bug-fix.md
+++ b/docs/agent-os/workflows/bug-fix.md
@@ -1,0 +1,45 @@
+# Workflow: Bug Fix (W-03)
+
+Modes: **Investigate** → **Build**
+Produces: Investigation Note, Implementation Plan, Verification Note
+
+---
+
+## Steps
+
+### Phase 1: Investigate
+
+1. Enter Investigate mode.
+2. Read the bug report. Identify the claimed behavior and expected behavior.
+3. Find the code path. Do not trust the report's diagnosis — verify it.
+4. Write a reproduction: confirm the bug exists in a test or via code trace.
+5. Identify the root cause. State it in one sentence.
+6. Assess risk: what else touches this code? What tests exist?
+7. Write Investigation Note.
+8. Write Implementation Plan. Bug fixes must be minimal:
+   - Fix the root cause
+   - Add a test that would have caught the bug
+   - Do not clean up surrounding code unless it is directly related
+
+### Phase 2: Approval
+
+Present the Investigation Note and Implementation Plan to the human.
+Do not proceed to Build without explicit approval.
+
+### Phase 3: Build
+
+1. Enter Build mode.
+2. Follow the Implementation Plan. Do not deviate.
+3. Fix only what the plan describes.
+4. Run `dotnet test` after the fix. All tests must pass.
+5. Confirm the new test catches the bug (it should fail without the fix).
+6. Write Verification Note.
+
+### Phase 4: Review
+
+Present the diff and Verification Note to the human.
+Commit only on explicit instruction.
+
+## Minimal fix rule
+
+A bug fix is not an opportunity to refactor. If surrounding code is messy, note it in the Verification Note as a follow-up item. Do not change it in the same commit.

--- a/docs/agent-os/workflows/docs-writing.md
+++ b/docs/agent-os/workflows/docs-writing.md
@@ -1,0 +1,57 @@
+# Workflow: Documentation Writing (W-09)
+
+Mode: **Content**
+Produces: Updated markdown in `docs/`, `README.md`, or `src/CacheManager.Redis/README.md`
+
+---
+
+## Three documentation surfaces
+
+This repo has three distinct doc surfaces. Know which one you are editing before you start.
+
+| Surface | File | Purpose | Audience |
+|---|---|---|---|
+| NuGet README | `src/CacheManager.Redis/README.md` | Shown on the NuGet package page | Anyone installing the package |
+| Repo README | `README.md` (root) | GitHub repo front page | Contributors, evaluators |
+| Standalone guides | `docs/*.md` | Deep-dive topics | Developers using the package |
+
+These files are related but not identical. The NuGet README focuses on usage. The repo README can include contributor information, roadmap, and development setup.
+
+## Steps
+
+1. Enter Content mode. Identify which surface you are updating and why.
+
+2. Read the current version of the file before editing. Never write docs from memory.
+
+3. Read the interface files before writing API usage:
+   - `src/CacheManager.Redis/Interfaces/IRedisCacheManager.cs`
+   - `src/CacheManager.Redis/Interfaces/IRedisDistributedCache.cs`
+   - `src/CacheManager.Redis/Extensions/Setup.cs`
+   
+   Every method name, parameter name, and return type in the docs must match the actual interface.
+
+4. Write or update the content.
+
+5. Check all code samples compile mentally. If uncertain, confirm against the actual source.
+
+6. Present the draft for review. Do not commit docs without review.
+
+## Rules
+
+- Do not describe methods that do not exist. Read the interface first.
+- Do not describe options that are not in `RedisCacheMangerOptions`.
+- Do not show a method signature in docs that differs from the actual signature.
+- If a doc references a version number (e.g., "added in v2.1.0"), verify it in `CHANGELOG.md`.
+- Do not add a "Roadmap" section unless the human explicitly provides roadmap content.
+
+## Keeping NuGet and repo README in sync
+
+The NuGet README and the root README will have overlapping content (installation, registration, core API usage). When one is updated, check whether the other needs the same update. They do not need to be identical, but they must not contradict each other.
+
+## When docs must be updated (not optional)
+
+- Any new public method or option → update NuGet README and root README
+- Any registration change → update both READMEs and the Sample
+- Any breaking change → add a migration note to the changelog and to the README
+
+Flag doc update requirements in the Verification Note at the end of every Build session that changes public API.

--- a/docs/agent-os/workflows/enhance.md
+++ b/docs/agent-os/workflows/enhance.md
@@ -1,0 +1,66 @@
+# Workflow: Enhancement Proposal (W-04)
+
+Modes: **Investigate** → **Build** (after approval)
+Produces: Investigation Note, Implementation Plan, Verification Note
+
+---
+
+## When to use
+
+- A new method or overload is proposed for `IRedisCacheManager<T>`
+- A new option is proposed for `RedisCacheMangerOptions`
+- A new registration helper is proposed for `Setup.cs`
+- A behavioral improvement is requested that does not fix a specific bug
+
+## Phase 1: Investigate the proposal
+
+Before writing a single line of implementation:
+
+1. Read the relevant interfaces and services in full.
+2. Answer these questions in the Investigation Note:
+   - **What exists today?** Describe the current behavior exactly.
+   - **What is the gap?** What can a user not do today that they should be able to?
+   - **Does it fit the library's scope?** CacheManager.Redis reduces boilerplate around typed Redis caching. Enhancements that add Redis data structures, pub/sub, or unrelated distributed systems concerns are out of scope.
+   - **Is there a public API change?** New interface methods are breaking for anyone using a custom `IRedisCacheManager<T>` implementation. This must be flagged explicitly.
+   - **What is the test surface?** What new test scenarios are needed?
+
+3. Write the Investigation Note.
+4. Stop. Present findings. Do not write the Implementation Plan until the direction is approved.
+
+## Phase 2: Implementation Plan
+
+Only after explicit approval of the direction:
+
+1. Write the Implementation Plan with the full scope.
+2. Pay particular attention to **Public API Changes**. If a method is added to `IRedisCacheManager<T>`, all of the following must be updated:
+   - The interface in `Interfaces/IRedisCacheManager.cs`
+   - The implementation in `Services/RedisCacheManager.cs`
+   - The fake in `test/CacheManager.Redis.Tests/Fakers/FakeCustomCacheManager.cs`
+   - The README (`README.md` and `src/CacheManager.Redis/README.md`) — update in the same Build session
+3. List any overloads that should be added alongside the primary change (e.g., sync + async variants).
+
+## Phase 3: Build
+
+Follow W-06. If the enhancement adds a new public method, README updates (`README.md` and `src/CacheManager.Redis/README.md`) must be completed in the same Build session — not deferred to Content mode. Note any README changes in the Verification Note.
+
+## Scope discipline
+
+Enhancement proposals often expand during implementation. If during Build you discover the plan needs to grow:
+1. Stop.
+2. Describe the expansion.
+3. Get approval.
+
+Do not add "while I'm in here" changes.
+
+## Breaking change rule
+
+Any change to `IRedisCacheManager<T>` or `IRedisDistributedCache` signatures is a **breaking change** for consumers who implement the interface themselves — most commonly in test fakes like `FakeCustomCacheManager`. Under strict semver this warrants a major version bump.
+
+This package uses a pragmatic interpretation: because most consumers only *inject* the interface rather than implement it, additive interface changes (new methods) are treated as minor bumps. Removals or signature changes to existing methods remain major bumps.
+
+**The rule:**
+- Removing or renaming an existing method on a public interface → **major** version bump
+- Adding a new method to a public interface → **minor** version bump, document it clearly
+- All interface changes → called out explicitly in the Implementation Plan and documented in the changelog under **Added** (new methods) or **Changed** (modified signatures)
+
+Regardless of version bump level, always update `FakeCustomCacheManager` in the same Build session or the test project will not compile.

--- a/docs/agent-os/workflows/explore.md
+++ b/docs/agent-os/workflows/explore.md
@@ -1,0 +1,44 @@
+# Workflow: Repo Exploration (W-01)
+
+Mode: **Explore**
+Produces: Exploration Summary (optional)
+
+---
+
+## When to use
+
+- Starting a new session with no prior context
+- Answering structural questions about the codebase
+- Understanding where a feature lives before investigating it
+- Giving a new collaborator a map of the repo
+
+## Steps
+
+1. Enter Explore mode. Only read-only and non-state-changing local validation commands are permitted in this mode.
+
+2. Read in this order:
+   - Repo root: `ls`, `README.md`, `CacheManager.Redis.sln`
+   - Source: `src/CacheManager.Redis/` — interfaces, services, extensions, options
+   - Tests: `test/CacheManager.Redis.Tests/` — test classes, fakes
+   - Sample: `Sample/` — entry point, controllers
+   - Docs: `docs/`
+
+3. Run `dotnet build` if you need to confirm the current build state.
+
+4. Answer the question asked. Flag any bugs, design issues, or improvement opportunities noticed — but stop short of proposing implementation details or producing an Implementation Plan.
+
+5. If the exploration reveals a bug or obvious gap, note it explicitly:
+   > "During exploration I noticed X. This may be worth investigating. Do you want me to switch to Investigate mode?"
+   Then stop.
+
+## Output
+
+If a written summary is requested, use the template at `docs/agent-os/templates/exploration-summary.md`.
+
+Save to `docs/agent-os/runs/` using the standard naming convention:
+
+```
+YYYY-MM-DD-<slug>-explore.md
+```
+
+Example: `2026-04-12-initial-codebase-explore.md`

--- a/docs/agent-os/workflows/github-release.md
+++ b/docs/agent-os/workflows/github-release.md
@@ -1,0 +1,68 @@
+# Workflow: GitHub Release (W-13)
+
+Mode: **Release**
+Requires: Validated .nupkg, merged PR on main, written release body
+
+---
+
+## Prerequisites
+
+- Package Validation Note is complete
+- Release commit exists on `main` locally (version bump, changelog, README, CLAUDE.md — created in Step 7 of the Release Workflow)
+- Tag `vX.Y.Z` exists locally (created in Step 7 of the Release Workflow)
+- Release body (changelog) is written and reviewed
+
+## Steps
+
+1. Confirm you are on `main` at the correct commit:
+   ```bash
+   git log --oneline -3
+   ```
+
+2. Confirm the tag exists:
+   ```bash
+   git tag -l vX.Y.Z
+   ```
+   Must output `vX.Y.Z`. If the tag is missing, create it now: `git tag vX.Y.Z`.
+
+3. **STOP. Confirm with human before pushing.**
+
+4. Push the release commit to `main`:
+   ```bash
+   git push origin main
+   ```
+
+5. Push the tag:
+   ```bash
+   git push origin vX.Y.Z
+   ```
+
+6. **STOP. Confirm with human before creating the release.**
+
+7. Create the GitHub release. Save the release body to a temp file first:
+   ```bash
+   # Write release body to a temp file
+   cat > /tmp/release-body.md << 'EOF'
+   <paste release body here>
+   EOF
+   
+   gh release create vX.Y.Z \
+     ./artifacts/CacheManager.Redis.X.Y.Z.nupkg \
+     --title "vX.Y.Z" \
+     --notes-file /tmp/release-body.md
+   ```
+
+8. Verify the release:
+   ```bash
+   gh release view vX.Y.Z
+   ```
+   Confirm: tag, title, body, attached .nupkg.
+
+9. Report back. Do not proceed to NuGet publish without instruction.
+
+## Error recovery
+
+If the tag was pushed but the release failed:
+- Do not create a new tag. Fix the release creation.
+- Use `gh release edit vX.Y.Z` if the release exists but is wrong.
+- If the tag itself is wrong, ask the human before deleting and recreating it.

--- a/docs/agent-os/workflows/implement.md
+++ b/docs/agent-os/workflows/implement.md
@@ -1,0 +1,52 @@
+# Workflow: Implementation (W-06)
+
+Mode: **Build**
+Requires: Approved Implementation Plan
+Produces: Working code + Verification Note
+
+---
+
+## Entry condition
+
+Do not enter Build mode without an approved Implementation Plan. If one does not exist, switch to Investigate and create one.
+
+## Steps
+
+1. Re-read the Implementation Plan before writing any code.
+
+2. Implement in the order specified in the plan. If no order is specified, work from the interface inward:
+   - Interface (if changed)
+   - Service implementation
+   - Extension/registration (if changed)
+   - Tests
+
+3. After each logical unit, run:
+   ```bash
+   dotnet build src/CacheManager.Redis/CacheManager.Redis.csproj
+   ```
+
+4. After all changes, run:
+   ```bash
+   dotnet test
+   ```
+   All tests must pass.
+
+5. Write Verification Note.
+
+## Scope discipline
+
+- Do not add features beyond the plan.
+- Do not rename variables, fix formatting, or clean up code outside the plan's scope.
+- Do not bump the version number — that belongs to Release mode.
+- Do not update `CHANGELOG.md` — that belongs to Release mode.
+- Update `README.md`, `src/CacheManager.Redis/README.md`, and `docs/` only when required to keep public documentation accurate with the implemented behavior. Unrelated doc rewrites or restructuring are out of scope.
+- If you encounter something that should be fixed but is out of scope, note it in the Verification Note under Follow-Up Items.
+
+## When implementation diverges from the plan
+
+If you discover during Build that the plan is wrong or needs adjustment:
+1. Stop.
+2. Describe the discrepancy.
+3. Get approval before proceeding.
+
+Do not silently deviate.

--- a/docs/agent-os/workflows/investigate.md
+++ b/docs/agent-os/workflows/investigate.md
@@ -1,0 +1,52 @@
+# Workflow: Investigation (W-02)
+
+Mode: **Investigate**
+Produces: Investigation Note + (optionally) Implementation Plan
+
+---
+
+## When to use
+
+- Before implementing any non-trivial change
+- When a bug report arrives and the root cause is unknown
+- When evaluating an enhancement idea
+- When a refactor is proposed and the scope is unclear
+
+## Steps
+
+1. Enter Investigate mode. State the question or bug.
+
+2. Read the relevant source files. Do not skim — read the actual implementation.
+
+3. Run targeted tests if needed to confirm behavior:
+   ```bash
+   dotnet test --filter "FullyQualifiedName~<TestClass>"
+   ```
+
+4. Trace the call path: from the interface through the service into the underlying IDistributedCache.
+
+5. Identify the root cause or gap. Write it down clearly before proceeding.
+
+6. Write the Investigation Note. See `docs/agent-os/templates/investigation-note.md`.
+
+7. If the recommendation is Fix or Enhance, write the Implementation Plan. See `docs/agent-os/templates/implementation-plan.md`.
+
+8. Stop. Present both artifacts. Do not start Build until the human approves.
+
+## Rules
+
+- Do not make permanent edits to source files during investigation.
+- Do not assume the bug is where the report says it is. Trace the actual code.
+- Do not write the Implementation Plan until the Investigation Note is complete.
+- Do not underestimate risk surface. Check what tests cover the area.
+- Remove all temporary diagnostic edits before ending the session. The only durable writes allowed are Investigation Notes and Implementation Plans in `docs/agent-os/runs/`.
+
+## Common investigation entry points
+
+| Scenario | Start here |
+|----------|-----------|
+| Bug in get/set behavior | `src/CacheManager.Redis/Services/RedisCacheManager.cs` |
+| Serialization issue | `src/CacheManager.Redis/Services/RedisCacheManager.cs` → JsonSerializer usage |
+| DI registration issue | `src/CacheManager.Redis/Extensions/Setup.cs` |
+| Options not applied | `src/CacheManager.Redis/RedisCacheMangerOptions.cs` |
+| Test failing unexpectedly | `test/CacheManager.Redis.Tests/` → relevant test class |

--- a/docs/agent-os/workflows/nuget-publish.md
+++ b/docs/agent-os/workflows/nuget-publish.md
@@ -1,0 +1,57 @@
+# Workflow: NuGet Publish (W-14)
+
+Mode: **Release**
+Requires: GitHub release live, validated .nupkg
+
+---
+
+## Prerequisites
+
+- GitHub release `vX.Y.Z` is live and confirmed
+- `.nupkg` path is known and validated
+- NuGet API key is available (in environment or will be provided)
+
+## Steps
+
+1. Confirm the .nupkg is the right one:
+   ```bash
+   ls -la ./artifacts/CacheManager.Redis.X.Y.Z.nupkg
+   ```
+
+2. **STOP. Confirm with human before running push.**
+
+3. Push to NuGet:
+   ```bash
+   dotnet nuget push ./artifacts/CacheManager.Redis.X.Y.Z.nupkg \
+     --api-key $NUGET_API_KEY \
+     --source https://api.nuget.org/v3/index.json \
+     --skip-duplicate
+   ```
+
+   `--skip-duplicate` prevents error if the version was already partially uploaded.
+   Never hardcode the API key in a command that will appear in session history.
+
+4. Wait for NuGet indexing. This typically takes 5–15 minutes.
+
+5. Verify:
+   - Package page: `https://www.nuget.org/packages/CacheManager.Redis/X.Y.Z`
+   - README renders correctly
+   - Dependencies are listed correctly
+   - Target frameworks are listed
+
+6. Write post-release note in `docs/agent-os/runs/`:
+   ```markdown
+   # Post-Release Note: vX.Y.Z
+   Date: YYYY-MM-DD
+   
+   - GitHub release: https://github.com/arefLA/CacheManager.Redis/releases/tag/vX.Y.Z — confirmed live
+   - NuGet: https://www.nuget.org/packages/CacheManager.Redis/X.Y.Z — confirmed live
+   - README renders correctly on NuGet: YES
+   - Known issues: none
+   ```
+
+## API key security
+
+- Never paste the API key directly into a command shown to the user if the session is being recorded or shared.
+- Prefer `$NUGET_API_KEY` environment variable.
+- If the human will type the key interactively, structure the command so the key is the last argument or piped from stdin.

--- a/docs/agent-os/workflows/orchestrate.md
+++ b/docs/agent-os/workflows/orchestrate.md
@@ -1,0 +1,69 @@
+# Workflow: Orchestrate (W-00)
+
+Mode: **Orchestrate**
+Produces: Updated `BACKLOG.md` status + all artifacts from the delegated mode
+
+---
+
+## Purpose
+
+Orchestrate is the entry point when you have a backlog of work and want Claude to select, plan, and execute tasks end-to-end — stopping at every gate for human verification.
+
+It does not replace the other modes. It selects the right mode for each task, confirms the approach with the human, manages transitions, and updates the backlog as work completes.
+
+---
+
+## Steps
+
+1. Read `docs/agent-os/BACKLOG.md`. List all pending tasks by priority.
+
+2. Present the list to the human. Ask which task to work on, or confirm starting the highest priority pending item.
+
+3. Analyze the selected task:
+   - What type is it? (see Task Type → Mode mapping below)
+   - What mode and workflow should start?
+   - Are there prerequisites? (e.g., a `release` task requires a Verification Note from a completed Build)
+
+4. Confirm the plan with the human before starting:
+   > "Task T-001 is a `bug`. I'll enter Investigate mode, trace the root cause, and produce an Investigation Note. Confirm to proceed."
+
+5. Update `BACKLOG.md`: mark the task `in-progress`, record the start date.
+
+6. Enter the appropriate mode. Follow the corresponding workflow. All gate rules from that mode apply without exception.
+
+7. At every gate, stop and wait for human input:
+   - After Investigation Note → wait for approval before writing Implementation Plan
+   - After Implementation Plan → wait for approval before entering Build
+   - After Verification Note → wait for instruction before entering Release
+   - Before any external action (push, release, publish) → wait for explicit per-action confirmation
+
+8. When the task is complete, update `BACKLOG.md`: mark as `complete`, record the released version (if applicable), and link the primary session artifact from `docs/agent-os/runs/`.
+
+9. Return to the backlog. Ask whether to continue with the next task or stop.
+
+---
+
+## Task type → mode mapping
+
+| Task type | Starting mode | Workflow |
+|---|---|---|
+| `bug` | Investigate | W-03: Bug Fix |
+| `feature` | Investigate | W-04: Enhancement |
+| `investigate` | Investigate | W-02: Investigation |
+| `refactor` | Investigate | W-05: Refactor |
+| `test` | Investigate (brief) | W-07: Test Writing |
+| `docs` | Content | W-09: Documentation Writing |
+| `sample` | Content | W-08: Sample Writing |
+| `content` | Content | W-10: SEO Article |
+| `release` | Release | W-12 → W-13 → W-14 |
+
+---
+
+## Rules
+
+- Do not start a task without human confirmation of the approach.
+- Do not skip any gate rule from the delegated mode — Orchestrate does not have elevated permissions.
+- Do not mark a task `complete` without human confirmation of the outcome.
+- If a task is blocked (missing prerequisite, ambiguous requirements, failed gate), mark it `blocked` in `BACKLOG.md` and report why.
+- Only one task should be `in-progress` at a time unless the human explicitly starts parallel work.
+- If a task's type is unclear, default to `investigate` — investigation is always safe.

--- a/docs/agent-os/workflows/package.md
+++ b/docs/agent-os/workflows/package.md
@@ -1,0 +1,73 @@
+# Workflow: Package (W-12)
+
+Mode: **Release**
+Produces: Validated .nupkg + Package Validation Note
+
+---
+
+## Prerequisites
+
+- Release Checklist pre-release section is complete
+- Version in `.csproj` is correct
+- `dotnet test` passes
+
+## Steps
+
+1. Build in Release configuration to confirm there are no errors or warnings:
+   ```bash
+   dotnet build src/CacheManager.Redis/CacheManager.Redis.csproj -c Release
+   ```
+   Must have 0 errors and 0 warnings.
+
+   Note: because `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` is set in the `.csproj`, this build also produces a `.nupkg` in `src/CacheManager.Redis/bin/Release/`. **Ignore that output entirely.** It goes to `bin/` which is `.gitignore`d and is not a valid release artifact. Use only the output from the explicit `dotnet pack` in the next step.
+
+2. Pack to the `./artifacts` directory (also `.gitignore`d — safe to produce locally):
+   ```bash
+   dotnet pack src/CacheManager.Redis/CacheManager.Redis.csproj -c Release -o ./artifacts
+   ```
+
+3. Inspect the package:
+   ```bash
+   unzip -l ./artifacts/CacheManager.Redis.X.Y.Z.nupkg
+   ```
+   Verify:
+   - `CacheManager.Redis.X.Y.Z.nuspec` — check version, description, tags
+   - `README.md` is present
+   - `lib/net6.0/` and `lib/net8.0/` are present
+   - No unexpected files
+
+4. Optionally install locally to test:
+   ```bash
+   dotnet nuget add source ./artifacts --name local-test
+   dotnet add Sample/Sample.csproj package CacheManager.Redis --version X.Y.Z --source local-test
+   dotnet build Sample/
+   # Then revert the reference
+   ```
+
+5. Write Package Validation Note:
+   ```markdown
+   # Package Validation Note: vX.Y.Z
+   Date: YYYY-MM-DD
+   
+   - Package ID: CacheManager.Redis confirmed
+   - Version: X.Y.Z confirmed
+   - README: present and correct
+   - Target frameworks: net6.0, net8.0 confirmed
+   - Dependencies: Ardalis.GuardClauses 5.x, Microsoft.Extensions.Caching.StackExchangeRedis 8.x confirmed
+   - Artifact path: ./artifacts/CacheManager.Redis.X.Y.Z.nupkg
+   - Build warnings: none
+   - Ready to publish: YES
+   ```
+
+6. Stop. Do not push or publish without instruction.
+
+## .csproj metadata check
+
+Before packing, confirm these fields in the `.csproj` are accurate:
+```xml
+<Title>Redis Cache Manager</Title>
+<Description>...</Description>
+<PackageTags>redis, cache manager, ...</PackageTags>
+<Version>X.Y.Z</Version>
+<PackageReadmeFile>README.md</PackageReadmeFile>
+```

--- a/docs/agent-os/workflows/refactor.md
+++ b/docs/agent-os/workflows/refactor.md
@@ -1,0 +1,63 @@
+# Workflow: Refactor (W-05)
+
+Modes: **Investigate** → **Build**
+Produces: Investigation Note, Implementation Plan, Verification Note
+
+---
+
+## When to use
+
+- Internal implementation is confusing, duplicated, or inconsistent
+- A method needs to be decomposed for testability
+- Naming is misleading (internal names only — public API renames are breaking changes)
+- Dead code needs to be removed
+
+## The refactor constraint
+
+A safe refactor changes internals without changing observable behavior. If the proposed change alters any of the following, it is not a refactor — it is an enhancement or a fix, and must use the appropriate workflow:
+
+- Any public interface signature
+- Any serialization behavior
+- Any DI registration behavior
+- Any exception type thrown on invalid input
+
+## Phase 1: Investigate
+
+1. Identify the specific problem with the current implementation. Write it down. "It's messy" is not a valid reason — name the actual issue: duplication, unclear responsibility, untestable path, etc.
+
+2. In the Investigation Note, document:
+   - Which files and methods are in scope
+   - What the observable behavior is today (becomes the pass/fail test for the refactor)
+   - What tests currently cover the area
+   - Whether any tests would need to be updated (test behavior should not change — only test setup if internal structure changes)
+
+3. Explicitly confirm: **no public API changes.** If public API must change, use W-04 (Enhance).
+
+## Phase 2: Implementation Plan
+
+The plan must include:
+
+- **Files touched** — list every file
+- **Public API changes** — must say "None"
+- **Before/after test count** — refactors should not reduce test coverage
+- **Out of scope** — be explicit about what is NOT being changed in this pass
+
+Large refactors should be broken into smaller plans. Each plan should be independently mergeable and independently verifiable.
+
+## Phase 3: Build
+
+1. Make the changes.
+2. Run `dotnet test` after every meaningful step, not just at the end.
+3. If any test fails, stop immediately. Do not continue until it passes. A refactor that breaks tests is a bug introduction, not a refactor.
+4. Write Verification Note.
+
+## The before/after rule
+
+Every refactor Verification Note must include:
+
+```
+Before: dotnet test — X passed
+After:  dotnet test — X passed (same count, same tests)
+```
+
+If the count changes, explain why in the Verification Note.

--- a/docs/agent-os/workflows/release-notes.md
+++ b/docs/agent-os/workflows/release-notes.md
@@ -1,0 +1,62 @@
+# Workflow: Release Notes / Changelist (W-11)
+
+Mode: **Release**
+Produces: Changelog entry + GitHub release body
+
+---
+
+## Steps
+
+1. Get the commit range:
+   ```bash
+   git log <previous-tag>..HEAD --oneline
+   # If no previous tag:
+   git log --oneline
+   ```
+
+2. Categorize commits:
+   - **Added**: new public API, new behavior, new options
+   - **Changed**: modified behavior, updated dependencies
+   - **Fixed**: bug fixes
+   - **Internal**: refactors, test additions, tooling, CI — not user-facing
+
+3. Write the changelog entry in `CHANGELOG.md`. See template in `docs/agent-os/templates/changelog-entry.md`.
+
+4. Write the GitHub release body. Same content, but add:
+   - A one-sentence summary at the top
+   - Installation line: `dotnet add package CacheManager.Redis --version X.Y.Z`
+   - Link to full changelog
+
+5. Human reviews both before they are used.
+
+## Rules
+
+- Write what changed, not why it was committed.
+- Do not include internal implementation details that package consumers don't care about.
+- Fixes that correct behavior introduced in the same release cycle can be omitted (they never shipped to users).
+- Keep entries short. One line per change is usually sufficient.
+
+## GitHub release body structure
+
+    ## CacheManager.Redis vX.Y.Z
+
+    <one-sentence summary of this release>
+
+    ```bash
+    dotnet add package CacheManager.Redis --version X.Y.Z
+    ```
+
+    ### What's changed
+
+    **Added**
+    - ...
+
+    **Fixed**
+    - ...
+
+    **Changed**
+    - ...
+
+    ---
+
+    [Full changelog](https://github.com/arefLA/CacheManager.Redis/blob/main/CHANGELOG.md)

--- a/docs/agent-os/workflows/sample.md
+++ b/docs/agent-os/workflows/sample.md
@@ -1,0 +1,61 @@
+# Workflow: Sample Writing (W-08)
+
+Mode: **Content**
+Produces: Working sample code in `Sample/`
+
+---
+
+## What the sample is for
+
+The `Sample/` project is an ASP.NET Core web application that demonstrates real usage of `CacheManager.Redis`. It is the first thing a new user looks at after reading the README. It must compile, run, and demonstrate correct usage — not a toy "hello world."
+
+## Current structure
+
+```
+Sample/
+├── Program.cs           — DI registration with AddRedisCacheManager
+├── Book.cs              — example model
+├── Controllers/         — controller using IRedisCacheManager<Book>
+├── appsettings.json     — Redis connection string config
+└── Sample.csproj        — project file
+```
+
+Follow this structure. Do not add significant complexity without good reason.
+
+## Steps
+
+1. Enter Content mode. Define the sample scenario clearly:
+   - What use case is being demonstrated?
+   - Is this a new scenario or an update to an existing one?
+   - What package version does it target?
+
+2. Read the current `Sample/` files before writing anything.
+
+3. Read the current interface at `src/CacheManager.Redis/Interfaces/IRedisCacheManager.cs` to confirm available methods.
+
+4. Write or update the sample.
+
+5. Verify it compiles:
+   ```bash
+   dotnet build Sample/Sample.csproj
+   ```
+   Must have 0 errors.
+
+6. If the sample references the package via NuGet (not local project reference), confirm the version in `Sample.csproj` matches the current released version.
+
+## Rules
+
+- Every code path shown in the sample must use the actual package API.
+- Do not demonstrate features that do not exist in the released version. If the sample is being written ahead of a release, note this explicitly.
+- Keep the sample simple. Its job is to show the pattern, not to be a full application.
+- The sample controller should demonstrate: `TryGet`, `SetAsync`, and at least one async `GetAsync` call.
+- Do not add sample code that requires infrastructure beyond a Redis connection (no databases, no external APIs).
+
+## When the sample needs updating
+
+The sample must be updated when:
+- A new API method is added that users should see used
+- Registration options change
+- The README shows a different usage pattern than the sample demonstrates
+
+Flag sample updates in the Verification Note when completing a Build session that changes the public API.

--- a/docs/agent-os/workflows/seo-content.md
+++ b/docs/agent-os/workflows/seo-content.md
@@ -1,0 +1,53 @@
+# Workflow: SEO Article / Technical Marketing Content (W-10)
+
+Mode: **Content**
+Produces: SEO Article Brief (approved) + markdown article in `docs/`
+
+---
+
+## Rules before writing a single word
+
+1. Complete the SEO Article Brief (`docs/agent-os/templates/seo-article-brief.md`).
+2. Get explicit approval on the brief.
+3. Only then begin writing.
+
+This prevents wasted work when the angle, keyword, or factual constraints are wrong.
+
+## Steps
+
+1. Enter Content mode. Identify:
+   - Target keyword
+   - Reader persona
+   - What problem the article solves
+
+2. Fill out the SEO Article Brief. Pay particular attention to **Factual Constraints**.
+
+3. Present the brief. Wait for approval.
+
+4. Write the article following the approved outline.
+   - Place the primary keyword in: H1 title, first paragraph, at least one H2, meta description.
+   - Every code sample must use actual CacheManager.Redis API (read the interfaces before writing samples).
+   - Explain what the code does. Do not just paste blocks.
+
+5. Flag any uncertainty:
+   > "I am not certain whether X is the current behavior — please verify before publishing."
+
+6. Save draft to `docs/<slug>.md`.
+
+7. Human reviews. Do not publish to any external platform.
+
+## What makes a good article for this package
+
+| Good | Bad |
+|------|-----|
+| Explains a real problem the package solves | Generic Redis overview with the package mentioned once |
+| Code samples that compile and run | Pseudocode or incomplete samples |
+| Honest trade-offs (e.g., when NOT to use this package) | Pure marketing copy |
+| Specific to .NET 6/8 and current package version | Vague references to ".NET" without version context |
+| One clear topic per article | Everything about Redis in one piece |
+
+## Tone
+
+- Direct. Senior developers do not need encouragement.
+- Specific. "The `SetAsync` method serializes using `System.Text.Json`" beats "the package handles serialization for you."
+- No adjectives that assert quality without evidence: not "seamless", not "powerful", not "robust".

--- a/docs/agent-os/workflows/test.md
+++ b/docs/agent-os/workflows/test.md
@@ -1,0 +1,47 @@
+# Workflow: Test Writing (W-07)
+
+Mode: **Build** (after brief Investigation)
+Produces: New test cases + Verification Note
+
+---
+
+## Existing test structure
+
+```
+test/CacheManager.Redis.Tests/
+├── Attributes/        — custom test attributes
+├── Extensions/        — extension method tests
+├── Fakers/            — fake/mock implementations (NSubstitute)
+├── Models/            — test model types
+└── Services/          — core service tests
+```
+
+Tests use xUnit and NSubstitute. Follow existing patterns.
+
+## Steps
+
+1. **Investigate first** (brief): identify what is not tested.
+   - Run `dotnet test --collect "Code Coverage"` if coverage tooling is configured.
+   - Or read the test classes and identify missing scenarios.
+
+2. Write Implementation Plan:
+   - List each test method to be added
+   - State what behavior each test asserts
+   - Note any new fakes or helpers needed
+
+3. Get approval.
+
+4. Enter Build mode. Write the tests. Follow existing naming conventions:
+   - `<Method>_<Scenario>_<ExpectedOutcome>`
+
+5. Run `dotnet test`. All tests pass.
+
+6. Write Verification Note listing each new test and what it asserts.
+
+## Rules
+
+- No skipped tests without an explanation comment.
+- Do not test implementation details — test the public interface.
+- Use `FakeCustomCacheManager` or NSubstitute patterns already in the project.
+- Each test must be independently runnable (no shared mutable state).
+- Do not add tests that duplicate existing coverage unless the existing test is wrong.

--- a/docs/redis-cache-dotnet-guide.md
+++ b/docs/redis-cache-dotnet-guide.md
@@ -1,0 +1,261 @@
+# Redis Cache in .NET: A Practical Guide for Modern Backends
+
+**Meta description:** Redis cache in .NET: a practical guide to distributed caching with StackExchange.Redis, IDistributedCache trade-offs, cache-aside patterns, and production best practices in .NET 8.
+
+---
+
+## Why Caching Matters in Modern .NET Applications
+
+Database and external API calls are often the slowest parts of a request. Repeated reads of the same data—product catalogs, user sessions, computed aggregates—multiply latency and load. Caching moves frequently accessed data closer to the application, reducing round-trips and giving users faster responses.
+
+In .NET, caching is usually implemented as an in-process cache (`IMemoryCache`) for single-instance apps or a **distributed cache** when you run multiple instances behind a load balancer. For the latter, Redis is one of the most common choices: it’s fast, supports TTLs and eviction, and is widely available in cloud and on-prem environments. This guide focuses on **Redis cache in .NET**—how to integrate it, what to watch out for, and how to use it effectively.
+
+---
+
+## What Redis Is and When to Use It
+
+Redis is an in-memory data store that can act as a cache, session store, or message broker. For caching, you typically use key-value operations with optional expiration (TTL). Benefits include:
+
+- **Sub-millisecond reads** for hot data
+- **Sliding and absolute expiration** so entries can expire after idle time or at a fixed point
+- **Shared state** across app instances, so cache is consistent in multi-node deployments
+- **Persistence options** if you need durability (less common for pure cache use cases)
+
+Use Redis when you have multiple .NET instances and need a **distributed cache** that all of them share. Use in-memory cache when you have a single instance and don’t need cross-process consistency.
+
+**Redis cache best practices** start with choosing the right tool: Redis for shared, multi-instance caching; in-memory for single-node speed without operational overhead.
+
+---
+
+## Common Redis Integration Approaches in .NET
+
+### Raw StackExchange.Redis
+
+[StackExchange.Redis](https://stackexchange.github.io/StackExchange.Redis/) is the standard .NET client for Redis. You get direct access to the full Redis API:
+
+```csharp
+var conn = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
+var db = conn.GetDatabase();
+await db.StringSetAsync("user:42", JsonSerializer.Serialize(user), TimeSpan.FromMinutes(30));
+var raw = await db.StringGetAsync("user:42");
+var user = JsonSerializer.Deserialize<User>(raw!);
+```
+
+You must manage serialization, key naming, TTLs, and connection lifecycle yourself. For a few keys this is fine; at scale it becomes repetitive and error-prone.
+
+### IDistributedCache and Its Limitations
+
+ASP.NET Core’s `IDistributedCache` abstracts the storage backend. The built-in Redis implementation (`AddStackExchangeRedisCache`) gives you a key–value store with `byte[]` only:
+
+```csharp
+await cache.SetAsync("user:42", Encoding.UTF8.GetBytes(JsonSerializer.Serialize(user)), options);
+var bytes = await cache.GetAsync("user:42");
+var user = JsonSerializer.Deserialize<User>(Encoding.UTF8.GetString(bytes));
+```
+
+**IDistributedCache vs Redis** in practice means: you still write serialization and deserialization at every call site. There is no strong typing, no shared serializer configuration, and no built-in convention for cache keys or default TTLs. You end up with boilerplate and inconsistent patterns across the codebase. Many teams adopt a small wrapper or helper library to centralize serialization and key naming; the next sections describe the kinds of issues that motivate that and one concrete option.
+
+---
+
+## Problems Developers Usually Face
+
+When integrating **Redis caching .NET** applications, a few pain points show up repeatedly:
+
+- **Serialization** – Deciding between JSON, MessagePack, or other formats, and applying the same options (naming, enums, null handling) everywhere.
+- **TTLs** – Mixing sliding vs absolute expiration and forgetting to set defaults, so some entries never expire.
+- **Cache keys** – No standard structure (e.g. `{instance}:{entity}:{id}`), leading to collisions or unmaintainable key strings.
+- **Boilerplate** – Repeated try-get, serialize, set, and error-handling code in every service.
+- **Testing** – Swapping Redis for an in-memory or fake implementation is possible but not trivial when logic is tied to raw `IDistributedCache` or `IDatabase`.
+
+A thin abstraction that keeps Redis and StackExchange.Redis under the hood but gives you typed get/set, consistent serialization, and configurable defaults can address most of these. You still rely on the same battle-tested client and ASP.NET Core integration; you just write less glue code and get a consistent **distributed cache .NET** style API. The next section describes one such option.
+
+---
+
+## Introducing CacheManager.Redis
+
+[CacheManager.Redis](https://www.nuget.org/packages/CacheManager.Redis) is an opinionated wrapper over `StackExchange.Redis` and the ASP.NET Core Redis distributed cache. It adds:
+
+- **Strongly-typed API** – `IRedisCacheManager<T>` so you work with your domain types instead of `byte[]`.
+- **Consistent serialization** – `System.Text.Json` with configurable options (camelCase, enums, etc.) applied globally.
+- **Default expiration** – Optional default `DistributedCacheEntryOptions` so every set can have a TTL without repeating options.
+- **Key prefixing** – Instance name support for multi-tenant or shared Redis instances.
+- **Async-first** – Async methods for all I/O, with sync variants where needed.
+
+It does not replace Redis or StackExchange.Redis; it sits on top of the standard stack and reduces boilerplate. Source and issues: [GitHub – arefLA/CacheManager.Redis](https://github.com/arefLA/CacheManager.Redis).
+
+---
+
+## Installation
+
+Add the package from NuGet (targets .NET 6 and .NET 8):
+
+```bash
+dotnet add package CacheManager.Redis
+```
+
+Ensure Redis is running and you have a connection string (host, port, password, SSL as required). For local development, something like `localhost:6379` is enough; for Azure Cache for Redis you might use `yourcache.redis.cache.windows.net:6380,password=...,ssl=True`.
+
+---
+
+## Basic Usage
+
+Register the cache manager in `Program.cs`:
+
+```csharp
+using CacheManager.Redis.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRedisCacheManager(
+    builder.Configuration.GetConnectionString("Redis")!,
+    options =>
+    {
+        options.InstanceName = "myapp:";
+        options.SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        options.DefaultCacheOptions = new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(30)
+        };
+    });
+```
+
+You get one `IRedisDistributedCache` (singleton) and one `IRedisCacheManager<T>` per entity type (scoped). Then inject `IRedisCacheManager<T>` and use it with your type:
+
+```csharp
+public sealed class ProductService
+{
+    private readonly IRedisCacheManager<Product> _cache;
+
+    public ProductService(IRedisCacheManager<Product> cache) => _cache = cache;
+
+    public async Task<Product?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var key = $"product:{id}";
+        var cached = await _cache.GetAsync(key, cancellationToken);
+        if (cached is not null)
+            return cached;
+
+        var product = await LoadFromDbAsync(id, cancellationToken);
+        if (product is not null)
+            await _cache.SetAsync(key, product, cancellationToken);
+
+        return product;
+    }
+}
+```
+
+`GetAsync` returns `null` on miss or invalid key. `SetAsync` uses your default cache options (e.g. 30-minute sliding expiration) unless you pass explicit `DistributedCacheEntryOptions`. No manual serialization or byte handling is required. For sync code you can use `TryGet(key, out var value)` and `Set` or `TrySet`; the same serializer and options apply. The library also exposes `TryRemove` and `TryRefresh` so you can avoid exceptions when keys are missing or invalid.
+
+---
+
+## Advanced Scenarios
+
+### Cache-Aside Pattern
+
+Cache-aside means: read from cache first; on miss, load from the source of truth (database, API), then write to cache. The snippet above is already cache-aside. A slightly more explicit version with per-call options:
+
+```csharp
+public async Task<Order?> GetOrderAsync(Guid orderId, CancellationToken cancellationToken = default)
+{
+    var key = $"order:{orderId}";
+    var order = await _cache.GetAsync(key, cancellationToken);
+    if (order is not null)
+        return order;
+
+    order = await _orderRepository.GetByIdAsync(orderId, cancellationToken);
+    if (order is null)
+        return null;
+
+    await _cache.SetAsync(key, order, new DistributedCacheEntryOptions
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)
+    }, cancellationToken);
+
+    return order;
+}
+```
+
+### Sliding vs Absolute Expiration
+
+- **Sliding** – Expiration timer resets on each read. Good for “recently used” data (e.g. session, recently viewed items). Use `SlidingExpiration` in `DistributedCacheEntryOptions`.
+- **Absolute** – Entry expires at a fixed time or after a fixed duration from now. Good for data that must be refreshed periodically (e.g. daily config). Use `AbsoluteExpiration` or `AbsoluteExpirationRelativeToNow`.
+
+You can combine both: the entry goes away when either the sliding window has passed without access or the absolute time is reached.
+
+```csharp
+await _cache.SetAsync(key, entity, new DistributedCacheEntryOptions
+{
+    SlidingExpiration = TimeSpan.FromMinutes(15),
+    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)
+}, cancellationToken);
+```
+
+### Async Usage
+
+Prefer async for all cache I/O to avoid blocking threads:
+
+```csharp
+var value = await _cache.GetAsync(key, cancellationToken);
+await _cache.SetAsync(key, entity, options, cancellationToken);
+await _cache.RefreshAsync(key, cancellationToken);
+await _cache.RemoveAsync(key, cancellationToken);
+```
+
+Use `TryGet` / `Set` / `TryRemove` / `TryRefresh` only when you’re in a sync context and cannot use async.
+
+### Cache Invalidation
+
+When the source data changes, remove or refresh the cached entry so the next read gets fresh data:
+
+```csharp
+public async Task UpdateProductAsync(Product product, CancellationToken cancellationToken = default)
+{
+    await _productRepository.UpdateAsync(product, cancellationToken);
+    await _cache.RemoveAsync($"product:{product.Id}", cancellationToken);
+}
+```
+
+For “refresh TTL but keep value,” use `RefreshAsync` so sliding expiration is reset without re-fetching from the database. If you need to invalidate by pattern (e.g. all keys under `product:*`), you’d need to either maintain a set of keys in Redis or use a separate mechanism (e.g. pub/sub or a tag/metadata layer); the current API is key-based only, which keeps the abstraction simple and matches typical cache-aside usage.
+
+---
+
+## Testing and Local Development
+
+- **Local Redis** – Run Redis in Docker (`docker run -d -p 6379:6379 redis`) or use a cloud/dev instance and point your connection string to it.
+- **Unit tests** – `IRedisCacheManager<T>` is interface-based. Use a fake or in-memory implementation in tests so you don’t depend on a real Redis server. The library supports registering a custom implementation via `options.CustomImplementation = typeof(YourFakeCacheManager<>);`.
+- **Integration tests** – Use a real Redis instance (e.g. Testcontainers) and the real `RedisCacheManager` to validate serialization and options. The project’s test suite uses this approach; see the [GitHub repo](https://github.com/arefLA/CacheManager.Redis) for examples.
+
+Avoid hardcoding connection strings; use configuration and environment-specific settings (e.g. `appsettings.Development.json`).
+
+---
+
+## Performance and Production Best Practices
+
+- **Connection** – CacheManager.Redis uses the same `IConnectionMultiplexer` as `AddStackExchangeRedisCache`; keep a single connection per app and reuse it.
+- **Serialization** – The library uses `System.Text.Json` and `SerializeToUtf8Bytes` to limit allocations. Reuse one `JsonSerializerOptions` via registration instead of creating new ones per call.
+- **Key design** – Use a clear, consistent key scheme (e.g. `{instance}:{entity}:{id}`) and the `InstanceName` option so multiple apps or environments don’t clash.
+- **TTLs** – Always set expiration so Redis doesn’t fill up; use defaults in registration plus overrides where needed.
+- **Observability** – Add a decorator (via `CustomImplementation`) to log cache hits/misses or record metrics. See the library’s [performance and observability notes](https://github.com/arefLA/CacheManager.Redis) if documented in the repo.
+
+These practices apply to any **distributed cache .NET** setup; CacheManager.Redis helps you apply them with less boilerplate. If you need custom behaviour (e.g. logging, metrics, or encryption), you can implement `IRedisCacheManager<T>` yourself and register it via `options.CustomImplementation = typeof(YourCacheManager<>);` so the DI container uses your implementation instead of the default one.
+
+---
+
+## When Not to Use Redis
+
+- **Single instance, no shared state** – `IMemoryCache` is simpler and has no network hop.
+- **Very large values** – Redis is better for small to medium values; consider chunking or a different store for huge payloads.
+- **Strong consistency requirements** – Cache is a performance optimization; use the database as the source of truth and invalidate on write.
+- **No ops for Redis** – If you can’t run, monitor, or patch Redis, use a managed service or stick to in-memory cache.
+
+---
+
+## Conclusion
+
+Using **Redis cache in .NET** reduces load on your database and improves response times when you have shared state across instances. Raw StackExchange.Redis is powerful but pushes serialization, key design, and TTL handling onto you. The built-in `IDistributedCache` with Redis standardizes the backend but still leaves you with byte arrays and repeated serialization code.
+
+An abstraction like CacheManager.Redis keeps the familiar StackExchange.Redis and ASP.NET Core stack while giving you a typed API, consistent JSON serialization, and sensible defaults. Install from [NuGet](https://www.nuget.org/packages/CacheManager.Redis), register with your connection string and options, inject `IRedisCacheManager<T>`, and implement cache-aside with sliding or absolute expiration as needed. Combine that with clear cache keys, explicit invalidation, and observability, and you have a solid **Redis caching .NET** setup that scales with your application. For source code, samples, and issue tracking, see the [GitHub repository](https://github.com/arefLA/CacheManager.Redis).


### PR DESCRIPTION
.gitignore had /docs/ and CLAUDE.md entries (added in dbf1a8c) that silently excluded the Agent OS spec, all workflows, templates, BACKLOG, session run artifacts, and the project bootstrap CLAUDE.md from version control. Removes those two lines; first commit of all previously-hidden files.